### PR TITLE
fixing toggle

### DIFF
--- a/icubam/www/static/map.js
+++ b/icubam/www/static/map.js
@@ -28,7 +28,8 @@ function togglePopup (cluster_id, color) {
 function toggleAll () {
   all_showed = !all_showed
   for (i = 0; i < data.length; i++) {
-    if ((!showed.has(data[i].label) && all_showed) || !all_showed) {
+    if ((!showed.has(data[i].label) && all_showed) ||
+        (!all_showed && (showed.has(data[i].label)))) {
       togglePopup(data[i].label, data[i].color)
     }
   }

--- a/resources/config.toml
+++ b/resources/config.toml
@@ -1,5 +1,5 @@
 # Keys
-version='0.1'
+version='0.1.1'
 
 # Tables
 [sms]


### PR DESCRIPTION
When the maps was all expanded and you clicked on one to remove it you have a map with N-1 objects. At this point, when toggling it would end up with 1 object on, instead of erasing them all, which is more natural.