### PR TITLE
unit tests should pass on a vanilla clone

### DIFF
--- a/.github/workflows/pythontest-linux.yml
+++ b/.github/workflows/pythontest-linux.yml
@@ -1,6 +1,6 @@
 name: Python package
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   test:
@@ -27,15 +27,10 @@ jobs:
     - name: Test with pytest
       shell: bash -l {0}
       env:
-        GSHEETS_TOKEN: ${{ secrets.gsheets_token }}
-        TOKEN_LOC: token.pickle
-        SHEET_ID: ${{ secrets.SHEET_ID }}
-        JWT_SECRET: ${{ secrets.JWT_SECRET }}
+        JWT_SECRET: faketest
       run: |
-        # Emit pickled gsheets testing credentials from CI secret
-        python -c "import pickle; import base64; import os; tok=pickle.loads(base64.b64decode(os.getenv('GSHEETS_TOKEN'))); tfile = open('token.pickle', 'wb'); pickle.dump(tok, tfile)"
         pip install pytest
-        pytest .
+        pytest --ignore icubam/db/test_gsheets.py
         pip install -e .
         python scripts/populate_db_fake.py --mode=dev
         timeout 5 python scripts/run_server.py || echo "Normal timeout" | grep "Normal timeout"

--- a/.github/workflows/pythontest-linux.yml
+++ b/.github/workflows/pythontest-linux.yml
@@ -30,7 +30,7 @@ jobs:
         JWT_SECRET: faketest
       run: |
         pip install pytest
-        pytest --ignore icubam/db/test_gsheets.py
+        pytest
         pip install -e .
         python scripts/populate_db_fake.py --mode=dev
         timeout 5 python scripts/run_server.py || echo "Normal timeout" | grep "Normal timeout"

--- a/icubam/db/test_gsheets.py
+++ b/icubam/db/test_gsheets.py
@@ -7,7 +7,7 @@ import unittest
 
 class GsheetsTest(absltest.TestCase):
   gsheets_tokens_def = all([os.environ.get(key, False)
-                             for key in ['SHEET_ID', 'TOKEN_LOC']])
+                           for key in ['SHEET_ID', 'TOKEN_LOC']])
 
   def setUp(self):
     super().setUp()

--- a/icubam/db/test_gsheets.py
+++ b/icubam/db/test_gsheets.py
@@ -1,18 +1,26 @@
 from icubam import config
 from icubam.db import gsheets
 from absl.testing import absltest
+import os
+import unittest
 
 
-class SQLiteDBTest(absltest.TestCase):
+class GsheetsTest(absltest.TestCase):
+  gsheets_tokens_def = all([os.environ.get(key, False)
+                             for key in ['SHEET_ID', 'TOKEN_LOC']])
 
   def setUp(self):
     super().setUp()
     self.config = config.Config('resources/test.toml', mode='dev')
 
+  @unittest.skipIf(not gsheets_tokens_def,
+                   "SHEET_ID or TOKEN_LOC env variables not set")
   def test_users(self):
     shdb = gsheets.SheetsDB(self.config.TOKEN_LOC, self.config.SHEET_ID)
     shdb.get_users()
 
+  @unittest.skipIf(not gsheets_tokens_def,
+                   "SHEET_ID or TOKEN_LOC env variables not set")
   def test_icus(self):
     shdb = gsheets.SheetsDB(self.config.TOKEN_LOC, self.config.SHEET_ID)
     shdb.get_icus()


### PR DESCRIPTION
Unit tests should pass from a "vanilla" clone without the need for tweaking / setting a configuration, and should not require secrets. Hence, this PR sets a dummy `JWT_TOKEN` env var for testing, disables `test_gsheets` as it requires a secret and enables github actions on pull requests to ease collaboration.