### PR TITLE
FIX Use pkg_resources for version determination in __init__

### DIFF
--- a/icubam/__init__.py
+++ b/icubam/__init__.py
@@ -1,8 +1,8 @@
-from importlib.metadata import version, PackageNotFoundError
+# pkg_resources is installed with setuptools
+from pkg_resources import get_distribution, DistributionNotFound
 
 try:
-  # Retrieving package version at runtime
-  __version__ = version(__name__)
-except PackageNotFoundError:
+  __version__ = get_distribution(__name__).version
+except DistributionNotFound:
   # package is not installed
   pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+setuptools>=42
 absl-py==0.9.0
 google-api-python-client==1.8.0
 google-auth-httplib2==0.0.3


### PR DESCRIPTION
A follow up fix on  https://github.com/icubam/icubam/pull/127 since `importlib.metadata` is not available in Python <=3.7 as detected by @olivierteboul 


This instead uses `pkg_resources` which is part of setuptools.

This adds `setuptools` to runtime dependencies (which is installed by pip by default regardless of dependencies anyway).


**Edit:** we only should merge this if we want to support Python <=3.7.