### PR TITLE
Fix dispatch pattern

### DIFF
--- a/.github/workflows/build-events.yml
+++ b/.github/workflows/build-events.yml
@@ -3,7 +3,7 @@ name: Emit Master Push Events to icubam_deploy
 on:
   push:
     tags:
-      - v*.rc[0-9]+
+      - 'v*.rc[0-9]+'
 
 jobs:
   send_request:

--- a/.github/workflows/build-events.yml
+++ b/.github/workflows/build-events.yml
@@ -3,7 +3,7 @@ name: Emit Master Push Events to icubam_deploy
 on:
   push:
     tags:
-      - 'v*.rc[0-9]+'
+      - v*rc[0-9]+
 
 jobs:
   send_request:


### PR DESCRIPTION
`.` is a litteral dot in the filter syntax. Fix release candidate dispatch filter.