### PR TITLE
Hotfix for dashboard

### DIFF
--- a/icubam/www/handlers/show.py
+++ b/icubam/www/handlers/show.py
@@ -32,7 +32,7 @@ class DataJson(base.BaseHandler):
       curr['n_covid_tot'] = free + occ
       curr['link'] = self.updater.get_url(count.icu.icu_id, count.icu.name)
       curr['icu_name'] = count.icu.name
-      for key in ['last_modified', 'create_date']:
+      for key in ['last_modified', 'create_date', 'icu']: # removing not necessary keys and not serializable keys such as Datetime data
         curr.pop(key, None)
 
       data.append(curr)


### PR DESCRIPTION
A new key `icu` appeared in the returned data dict. This key corresponds to a dict that contained not serializable data types such as DateTime. Leading to a server error that propagated to an Ajax error and not showing the dashboard's table.

Fixed this issue by just removing the corresponding key `icu` which did not any data used on the front end for now.