### PR TITLE
Update dev_install.md

### DIFF
--- a/dev_install.md
+++ b/dev_install.md
@@ -43,7 +43,7 @@ The database will be named `test.db`, cf. `resources/config.toml`.
 
 ## Running unit tests
 
-The unit tests require `TOKEN_LOC` to be set with a valid `token.pickle` file in the `resources/.env` file.
+A few unit tests require `TOKEN_LOC` to be set with a valid `token.pickle` file in the `resources/.env` file. If the TOKEN_LOC variable is not present, those tests will be skipped.
 
 To start the tests, install `pytest` and run `pytest`
 


### PR DESCRIPTION
We changed the unit tests to skip gsheets-related tests if the corresponding secret was not defined; update the developer documentation accordingly.