### PR TITLE
Optionally render extra plots in the /operational-dashboard

### DIFF
--- a/icubam/backoffice/handlers/operational_dashboard.py
+++ b/icubam/backoffice/handlers/operational_dashboard.py
@@ -127,7 +127,7 @@ def _grouper(iterable, n, fillvalue=None):
   ABC DEF Gxx
   """
   args = [iter(iterable)] * n
-  return zip_longest(fillvalue=fillvalue, *args)
+  return list(zip_longest(fillvalue=fillvalue, *args))
 
 
 def _list_extra_plots(input_dir: Path) -> List[str]:

--- a/icubam/backoffice/handlers/operational_dashboard.py
+++ b/icubam/backoffice/handlers/operational_dashboard.py
@@ -1,5 +1,8 @@
 from typing import List, Dict
 
+import os
+from pathlib import Path
+from itertools import zip_longest
 import numpy as np
 import pandas as pd
 import tornado.web
@@ -113,6 +116,35 @@ def _make_bar_plot(df: pd.DataFrame):
   return p
 
 
+def _grouper(iterable, n, fillvalue=None):
+  """Collect data into fixed-length chunks or blocks
+
+  Copied from https://docs.python.org/3.8/library/itertools.html#itertools-recipes
+  
+  Example
+  -------
+  >>> grouper('ABCDEFG', 3, 'x')
+  ABC DEF Gxx
+  """
+  args = [iter(iterable)] * n
+  return zip_longest(fillvalue=fillvalue, *args)
+
+
+def _list_extra_plots(input_dir: Path) -> List[str]:
+  """Return a list of available plot names"""
+  if not isinstance(input_dir, Path):
+    raise ValueError(f'input_dir={input_dir} must be a Path object')
+  if not input_dir.exists():
+    return []
+  out = []
+  for fpath in os.listdir(input_dir):
+    fpath = Path(fpath)
+    if fpath.suffix != '.png':
+      continue
+    out.append(fpath.stem)
+  return list(sorted(out))
+
+
 class OperationalDashHandler(base.AdminHandler):
   ROUTE = 'operational-dashboard'
 
@@ -150,6 +182,12 @@ class OperationalDashHandler(base.AdminHandler):
     script, div = components(p)
     figures.append(dict(script=script, div=div))
 
+    plots_extra = _list_extra_plots(
+      Path(self.config.backoffice.extra_plots_dir)
+    )
+    # stack two columns per row
+    plots_extra = _grouper(plots_extra, 2)
+
     regions = [{
       'name': el.name,
       'id': el.region_id
@@ -161,5 +199,6 @@ class OperationalDashHandler(base.AdminHandler):
       figures=figures,
       regions=regions,
       current_region_name=current_region_name,
-      metrics_layout=metrics_layout
+      metrics_layout=metrics_layout,
+      plots_extra=plots_extra
     )

--- a/icubam/backoffice/server.py
+++ b/icubam/backoffice/server.py
@@ -78,6 +78,13 @@ class BackOfficeServer(base_server.BaseServer):
     self.add_handler(messages.ListMessagesHandler)
     self.add_handler(maps.MapsHandler)
 
+    if os.path.isdir(self.config.backoffice.extra_plots_dir):
+      route = os.path.join("/", self.root, r'static/extra-plots/(.*)')
+      self.routes.append(
+          (route, tornado.web.StaticFileHandler,
+          {'path': self.config.backoffice.extra_plots_dir})
+          )
+
     for folder in ['dist', 'pages', 'plugins', 'static']:
       route = os.path.join("/", self.root, folder, r'(.*)')
       folder = '' if folder == 'static' else folder

--- a/icubam/backoffice/static/dist/css/dashboard.css
+++ b/icubam/backoffice/static/dist/css/dashboard.css
@@ -18,3 +18,8 @@ div.operational-dash .dash-metrics .card-title {
 div.operational-dash .dash-metrics .card-text {
     font-size: small;
 }
+
+div.operational-dash .figure img {
+    width: 100%;
+}
+

--- a/icubam/backoffice/templates/operational-dashboard.html
+++ b/icubam/backoffice/templates/operational-dashboard.html
@@ -70,6 +70,27 @@
         {% end %}
         </div>
     </div>
+
+    {% if plots_extra %}
+    <div class="row">
+    <div class="col">
+    <h2>{{ _("Extra figures") }}</h1>
+    </div>
+    </div>
+    {% end %}
+
+    {% for row in plots_extra %}
+    <div class="row extra-plots">
+    {% for fig_name in row %}
+    {% if fig_name is not None %}
+        <div class="col-sm-5 figure">
+	   <img src="/bo/static/extra-plots/{{ fig_name }}.png" />
+    
+	</div>
+    {% end %}
+    {% end %}
+    </div>
+    {% end %}
 </div>
 
 {% end %}

--- a/resources/config.toml
+++ b/resources/config.toml
@@ -61,7 +61,9 @@ default_locale='fr-fr'
     port = 8890
     ping_every = 60  # in seconds
     root = 'admin'
+    extra_plots_dir = "/tmp/dasboard_plots_dir"
   [backoffice.dev]
     port = 8890
     ping_every = 60  # in seconds
     root = 'bo'
+    extra_plots_dir = "/tmp/dasboard_plots_dir"

--- a/resources/test.toml
+++ b/resources/test.toml
@@ -46,3 +46,4 @@ sqlite_path = ":memory:"
   port = 8979
   ping_every = 60
   root = 'mybo'
+  extra_plots_dir = "/tmp/dasboard_plots_dir"


### PR DESCRIPTION
This adds an `extra_plots_dir` config parameter to `config.toml`. When it points to an existing dir, any png figure in that folder will be rendered at the end of `/operational-dashboard` page.

This is fully optional, if the `extra_plots_dir` is a non existing path or a folder with no `.png`, the previous behavour is unchanged.

TODO:
 - [ ] add a few tests
 - [ ] document this feature

Will add a separate PR to re-generate these figures periodically.