### PR TITLE
Trigger CI on PRs or push in master

### DIFF
--- a/.github/workflows/db-wipe-smoketest.yml
+++ b/.github/workflows/db-wipe-smoketest.yml
@@ -1,6 +1,14 @@
 name: DB wipe script smoke test
 
-on: [push, pull_request]
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the master branch
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   test:

--- a/.github/workflows/docker-build-run.yml
+++ b/.github/workflows/docker-build-run.yml
@@ -1,6 +1,14 @@
 name: Build Docker image and test container
 
-on: [pull_request]
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the master branch
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   test:

--- a/.github/workflows/pythontest-linux.yml
+++ b/.github/workflows/pythontest-linux.yml
@@ -1,6 +1,14 @@
 name: Python package
 
-on: [push, pull_request]
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the master branch
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   test:


### PR DESCRIPTION
Avoid redundant CI jobs when PRs are opened from upstream branches.

Makes CI trigger from either PRs to master or pushes to master (e.g. when the PR is merged).