### PR TITLE
Use Tox to run the tests

### DIFF
--- a/.github/workflows/pythontest-linux.yml
+++ b/.github/workflows/pythontest-linux.yml
@@ -31,17 +31,11 @@ jobs:
       run: |
         which python
         pip --version
-        pip install -r requirements.txt
+        pip install tox
     - name: Test with pytest
       shell: bash -l {0}
-      env:
-        JWT_SECRET: faketest
       run: |
-        set -x
-        pip install pytest
-        pip install pytest-cov
-        pip install -e .
-        pytest --cov=icubam --cov-report=xml --cov-report=html
+        tox -e tests
 #    - name: "Upload coverage to Codecov"
 #      uses: "codecov/codecov-action@v1"
 #      with:

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,11 @@ __pycache__/
 # Mac and Vscode settings
 .DS_Store
 settings.json
+
+# Tox
+.tox/
+
+# coverage
+htmlcov/
+coverage.xml
+.coverage

--- a/doc/install.md
+++ b/doc/install.md
@@ -45,7 +45,7 @@ The database will be named `test.db`, cf. `resources/config.toml`.
 
 A few unit tests require `TOKEN_LOC` to be set with a valid `token.pickle` file in the `resources/.env` file. If the TOKEN_LOC variable is not present, those tests will be skipped.
 
-To start the tests, install `pytest` and run `pytest`
+To start the tests, install `tox` and run `tox`
 
 ## Running locally
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+envlist = tests
+
+[testenv]
+basepython=python3
+setenv =
+    JWT_SECRET = faketest 
+deps=
+    -rrequirements.txt
+    pytest-cov
+commands=
+    pytest --cov=icubam --cov-report=term --cov-report=xml --cov-report=html --cov-report=term-missing -v {posargs}


### PR DESCRIPTION
This can be useful for local testing.

Other stuff added: print the coverage results in the terminal and also the lines not covered by tests.

The tests performed on the CI are adapted. We could also add a testenv for the db-wipe-smoketest.yml ?

I'm also wondering how this will work on the CI with conda.