### PR TITLE
Refactor config paths

### DIFF
--- a/doc/install.md
+++ b/doc/install.md
@@ -15,7 +15,7 @@ Steps:
 
 ### Configuration
 
-Create a `resources/.env` file containing the following keys:
+Create a `resources/icubam.env` file containing the following keys:
 ```
 SHEET_ID=
 TOKEN_LOC=
@@ -43,7 +43,7 @@ The database will be named `test.db`, cf. `resources/config.toml`.
 
 ## Running unit tests
 
-A few unit tests require `TOKEN_LOC` to be set with a valid `token.pickle` file in the `resources/.env` file. If the TOKEN_LOC variable is not present, those tests will be skipped.
+A few unit tests require `TOKEN_LOC` to be set with a valid `token.pickle` file in the `resources/icubam.env` file. If the TOKEN_LOC variable is not present, those tests will be skipped.
 
 To start the tests, install `pytest` and run `pytest`
 

--- a/icubam/config.py
+++ b/icubam/config.py
@@ -7,7 +7,7 @@ from dotenv import load_dotenv
 import dotmap
 import toml
 
-DEFAULT_DOTENV_PATH = "resources/.env"
+DEFAULT_DOTENV_PATH = "resources/icubam.env"
 DEFAULT_CONFIG_PATH = "resources/config.toml"
 
 

--- a/icubam/config.py
+++ b/icubam/config.py
@@ -7,6 +7,9 @@ from dotenv import load_dotenv
 import dotmap
 import toml
 
+DEFAULT_DOTENV_PATH = "resources/.env"
+DEFAULT_CONFIG_PATH = "resources/config.toml"
+
 
 class Config:
   """A class to read the configuration both from .env and from a toml file.

--- a/scripts/csv_export.py
+++ b/scripts/csv_export.py
@@ -4,8 +4,8 @@ from icubam import config
 import icubam.db.store as db_store
 from icubam.db import synchronizer
 
-flags.DEFINE_string("config", "resources/config.toml", "Config file.")
-flags.DEFINE_string("dotenv_path", "resources/.env", "Config file.")
+flags.DEFINE_string("config", config.DEFAULT_CONFIG_PATH, "Config file.")
+flags.DEFINE_string("dotenv_path", config.DEFAULT_DOTENV_PATH, "Config file.")
 flags.DEFINE_enum("mode", "dev", ["prod", "dev"], "Run mode.")
 
 flags.DEFINE_string("output", None, "Path for export.")

--- a/scripts/csv_import.py
+++ b/scripts/csv_import.py
@@ -4,8 +4,8 @@ from icubam import config
 import icubam.db.store as db_store
 from icubam.db import synchronizer
 
-flags.DEFINE_string("config", "resources/config.toml", "Config file.")
-flags.DEFINE_string("dotenv_path", "resources/.env", "Config file.")
+flags.DEFINE_string("config", config.DEFAULT_CONFIG_PATH, "Config file.")
+flags.DEFINE_string("dotenv_path", config.DEFAULT_DOTENV_PATH, "Config file.")
 flags.DEFINE_enum("mode", "dev", ["prod", "dev"], "Run mode.")
 
 flags.DEFINE_bool(

--- a/scripts/generate_api_key.py
+++ b/scripts/generate_api_key.py
@@ -6,8 +6,11 @@ from absl import logging
 from icubam import config
 from icubam.db import store
 
-flags.DEFINE_string('config', 'resources/config.toml', 'Config file.')
-flags.DEFINE_string('dotenv_path', None, 'Optionally specifies the .env path.')
+flags.DEFINE_string('config', config.DEFAULT_CONFIG_PATH, 'Config file.')
+flags.DEFINE_string(
+  'dotenv_path', config.DEFAULT_DOTENV_PATH,
+  'Optionally specifies the .env path.'
+)
 flags.DEFINE_enum('mode', 'dev', ['prod', 'dev'], 'Run mode.')
 flags.DEFINE_string('name', None, 'Meta data.')
 flags.DEFINE_string('email', None, 'Meta data.')

--- a/scripts/get_id_url.py
+++ b/scripts/get_id_url.py
@@ -7,8 +7,11 @@ from icubam import config
 from icubam.www import token
 from icubam.db import store
 
-flags.DEFINE_string('config', 'resources/config.toml', 'Config file.')
-flags.DEFINE_string('dotenv_path', None, 'Optionally specifies the .env path.')
+flags.DEFINE_string('config', config.DEFAULT_CONFIG_PATH, 'Config file.')
+flags.DEFINE_string(
+  'dotenv_path', config.DEFAULT_DOTENV_PATH,
+  'Optionally specifies the .env path.'
+)
 flags.DEFINE_enum('mode', 'dev', ['prod', 'dev'], 'Run mode.')
 flags.DEFINE_boolean('all', False, 'Get all ids')
 

--- a/scripts/migrate_db.py
+++ b/scripts/migrate_db.py
@@ -4,8 +4,8 @@ from icubam import config
 from icubam.db import migrator
 import click
 
-flags.DEFINE_string("config", "resources/config.toml", "Config file.")
-flags.DEFINE_string("dotenv_path", "resources/.env", "Config file.")
+flags.DEFINE_string("config", config.DEFAULT_CONFIG_PATH, "Config file.")
+flags.DEFINE_string("dotenv_path", config.DEFAULT_DOTENV_PATH, "Config file.")
 flags.DEFINE_enum("mode", "dev", ["prod", "dev"], "Run mode.")
 FLAGS = flags.FLAGS
 

--- a/scripts/populate_db.py
+++ b/scripts/populate_db.py
@@ -7,8 +7,8 @@ from icubam.db import sqlite
 from icubam.db import gsheets
 from icubam.db import synchronizer
 
-flags.DEFINE_string("config", "resources/config.toml", "Config file.")
-flags.DEFINE_string("dotenv_path", "resources/.env", "Config file.")
+flags.DEFINE_string("config", config.DEFAULT_CONFIG_PATH, "Config file.")
+flags.DEFINE_string("dotenv_path", config.DEFAULT_DOTENV_PATH, "Config file.")
 flags.DEFINE_enum("mode", "dev", ["prod", "dev"], "Run mode.")
 FLAGS = flags.FLAGS
 

--- a/scripts/populate_db_fake.py
+++ b/scripts/populate_db_fake.py
@@ -5,8 +5,8 @@ from icubam import config
 import icubam.db.store as db_store
 from icubam.db.fake import populate_store_fake
 
-flags.DEFINE_string("config", "resources/config.toml", "Config file.")
-flags.DEFINE_string("dotenv_path", "resources/.env", "Config file.")
+flags.DEFINE_string("config", config.DEFAULT_CONFIG_PATH, "Config file.")
+flags.DEFINE_string("dotenv_path", config.DEFAULT_DOTENV_PATH, "Config file.")
 flags.DEFINE_enum("mode", "dev", ["prod", "dev"], "Run mode.")
 FLAGS = flags.FLAGS
 

--- a/scripts/run_server.py
+++ b/scripts/run_server.py
@@ -9,8 +9,11 @@ from icubam.messaging import server as msg_server
 from icubam.www import server as www_server
 
 flags.DEFINE_integer('port', None, 'Port of the application.')
-flags.DEFINE_string('config', 'resources/config.toml', 'Config file.')
-flags.DEFINE_string('dotenv_path', None, 'Optionally specifies the .env path.')
+flags.DEFINE_string('config', config.DEFAULT_CONFIG_PATH, 'Config file.')
+flags.DEFINE_string(
+  'dotenv_path', config.DEFAULT_DOTENV_PATH,
+  'Optionally specifies the .env path.'
+)
 flags.DEFINE_enum('mode', 'dev', ['prod', 'dev'], 'Run mode.')
 flags.DEFINE_string('server', 'www', 'File for the db.')
 FLAGS = flags.FLAGS

--- a/scripts/schedule_sms.py
+++ b/scripts/schedule_sms.py
@@ -6,8 +6,11 @@ import tornado.ioloop
 from icubam import config
 from icubam.messaging import server
 
-flags.DEFINE_string('config', 'resources/config.toml', 'Config file.')
-flags.DEFINE_string('dotenv_path', None, 'Optionally specifies the .env path.')
+flags.DEFINE_string('config', config.DEFAULT_CONFIG_PATH, 'Config file.')
+flags.DEFINE_string(
+  'dotenv_path', config.DEFAULT_DOTENV_PATH,
+  'Optionally specifies the .env path.'
+)
 flags.DEFINE_enum('mode', 'dev', ['prod', 'dev', 'staging'], 'Run mode.')
 flags.DEFINE_integer('delay', None, 'time in seconds to schedule next batch.')
 FLAGS = flags.FLAGS

--- a/scripts/send_sms.py
+++ b/scripts/send_sms.py
@@ -4,8 +4,11 @@ from absl import logging
 from icubam import config
 from icubam.messaging import sms_sender
 
-flags.DEFINE_string('config', 'resources/config.toml', 'Config file.')
-flags.DEFINE_string('dotenv_path', None, 'Optionally specifies the .env path.')
+flags.DEFINE_string('config', config.DEFAULT_CONFIG_PATH, 'Config file.')
+flags.DEFINE_string(
+  'dotenv_path', config.DEFAULT_DOTENV_PATH,
+  'Optionally specifies the .env path.'
+)
 flags.DEFINE_string('phone', None, 'The number to send the sms to.')
 flags.DEFINE_enum('mode', 'dev', ['prod', 'dev'], 'Run mode.')
 FLAGS = flags.FLAGS

--- a/scripts/synchronize_db.py
+++ b/scripts/synchronize_db.py
@@ -6,8 +6,8 @@ from icubam.db import store
 from icubam.db import gsheets
 from icubam.db import synchronizer
 
-flags.DEFINE_string("config", "resources/config.toml", "Config file.")
-flags.DEFINE_string("dotenv_path", "resources/.env", "Config file.")
+flags.DEFINE_string("config", config.DEFAULT_CONFIG_PATH, "Config file.")
+flags.DEFINE_string("dotenv_path", config.DEFAULT_DOTENV_PATH, "Config file.")
 flags.DEFINE_enum("mode", "dev", ["prod", "dev"], "Run mode.")
 flags.DEFINE_bool('newdb', True, 'Old sqliteDB or new Store.')
 FLAGS = flags.FLAGS

--- a/scripts/update_password.py
+++ b/scripts/update_password.py
@@ -6,8 +6,11 @@ from absl import logging
 from icubam import config
 from icubam.db import store
 
-flags.DEFINE_string('config', 'resources/config.toml', 'Config file.')
-flags.DEFINE_string('dotenv_path', None, 'Optionally specifies the .env path.')
+flags.DEFINE_string('config', config.DEFAULT_CONFIG_PATH, 'Config file.')
+flags.DEFINE_string(
+  'dotenv_path', config.DEFAULT_DOTENV_PATH,
+  'Optionally specifies the .env path.'
+)
 flags.DEFINE_enum('mode', 'dev', ['prod', 'dev'], 'Run mode.')
 flags.DEFINE_string('email', None, 'File for the db.')
 flags.DEFINE_string('password', None, 'File for the db.')


### PR DESCRIPTION
This PR follows suggestions made in https://github.com/icubam/icubam/pull/117#discussion_r401226576

As a side effect, it also makes instructions in `doc/install.md` succeed when they were previously failing to launch `run_server.py` because of a missing path to the `.env` file.