### PR TITLE
Add script to check docker-compose's status

### DIFF
--- a/docker/scripts/status.sh
+++ b/docker/scripts/status.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+set -e
+
+[ -n "${DEBUG}" ] && set -x
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DOCKER_DIR="$(dirname "${DIR}")"
+PROJECT_DIR="$(dirname "${DOCKER_DIR}")"
+WRITE_LOGS="${WRITE_LOGS:-1}"
+TMPDIR="${TMPDIR:-/tmp}"
+LOGS_DIR="${LOGS_DIR:-"${TMPDIR}"}"
+LOGS_NUM_LINES="${LOGS_NUM_LINES:-2}"
+
+function print_status() {
+  local cid="${1}"
+  echo "----------------------------------------"
+  docker inspect --format 'ID: {{.ID}}' "${cid}"
+  docker inspect --format 'Name: {{.Name}}' "${cid}"
+  docker inspect --format 'Image: {{.Config.Image}}' "${cid}"
+  docker inspect --format 'Status: {{.State.Status}}' "${cid}"
+  echo "Logs:"
+  echo "-----"
+  docker logs "${cid}" | tail -n "${LOGS_NUM_LINES}"
+}
+
+function container_name() {
+  local cid="${1}"
+  # inspecting returns "/${container_name}", we therefore remove the leading "/":
+  docker inspect --format '{{join (split .Name "/") ""}}' "${cid}"
+}
+
+function log_to_file() {
+  local cid="${1}"
+  docker logs "${cid}" > "${LOGS_DIR}/$(container_name "${cid}").log"
+}
+
+function detailed_status() {
+  local status_code=0
+  for cid in $(docker-compose -f "${DOCKER_DIR}/docker-compose.yml" --project-directory "${PROJECT_DIR}" ps -q); do
+    if [ "$(docker inspect -f '{{.State.Status}}' "${cid}")" != "running" ]; then
+      status_code=1
+      print_status "${cid}"
+      if [ "${WRITE_LOGS}" == "1" ]; then
+        log_to_file "${cid}"
+      fi
+    fi
+  done
+  return ${status_code}
+}
+
+function status() {
+  docker-compose -f "${DOCKER_DIR}/docker-compose.yml" --project-directory "${PROJECT_DIR}" ps
+}
+
+function main() {
+  status
+  detailed_status
+}
+
+main


### PR DESCRIPTION
### Why?

Make it easier to quickly check the status of the `docker-compose` deployment.
This is useful for both developers and for CICD.

### QA

#### Linting

```console
$ shellcheck docker/scripts/status.sh
# No warning/error returned by shellcheck

$ shellcheck --version
ShellCheck - shell script analysis tool
version: 0.7.1
license: GNU General Public License, version 3
website: https://www.shellcheck.net
```

#### Manual Testing

```console
$ ./docker/scripts/status.sh
      Name                     Command                 State                       Ports
----------------------------------------------------------------------------------------------------------
icubam-bo-server    /bin/bash -c ./start_serve ...   Restarting
icubam-server       /bin/bash -c ./start_server.sh   Restarting
icubam-sms-server   /bin/bash -c ./start_serve ...   Restarting
icubam_certbot_1    /bin/sh -c trap exit TERM; ...   Up           443/tcp, 80/tcp
icubam_nginx_1      /bin/sh -c while :; do sle ...   Up           0.0.0.0:443->443/tcp, 0.0.0.0:80->80/tcp
----------------------------------------
ID: 5cfa3a66576460c6ccff0f089e0746e5d28d8e3a9633db8be65a26b35219725d
Name: /icubam-bo-server
Image: icubam:latest
Status: restarting
Logs:
-----
sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) unable to open database file
(Background on this error at: http://sqlalche.me/e/e3q8)
----------------------------------------
ID: 0d23af5356b9072eaa8a641136dfdfd8e4dc412eeebb87fc5a7e0dfd58d2b249
Name: /icubam-server
Image: icubam:latest
Status: restarting
Logs:
-----
sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) unable to open database file
(Background on this error at: http://sqlalche.me/e/e3q8)
----------------------------------------
ID: 57090c7c579fcbf1a7c244c8512b50f438ca41f1da631d8f49c74af1d689bf53
Name: /icubam-sms-server
Image: icubam:latest
Status: restarting
Logs:
-----
sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) unable to open database file
(Background on this error at: http://sqlalche.me/e/e3q8)
```

N.B.: appropriate status code is returned when all containers aren't `running`:

```console
$ echo $?
1
```

Full logs are generated by default (but this can be disabled by setting `WRITE_LOGS=0`):

```console
$ ls -1 ${TMPDIR}*.log
/var/folders/24/d3mml6bn20nftpt91cfldq1h0000gn/T/icubam-bo-server.log
/var/folders/24/d3mml6bn20nftpt91cfldq1h0000gn/T/icubam-server.log
/var/folders/24/d3mml6bn20nftpt91cfldq1h0000gn/T/icubam-sms-server.log
```
