### PR TITLE
Lint shell scripts as part of CI

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,22 @@
+name: run shellcheck on all shell scripts
+
+on: push
+
+jobs:
+  shellcheck:
+    env:
+      VERSION: "v0.7.1"
+      SHA256_HASH: "64f17152d96d7ec261ad3086ed42d18232fcb65148b44571b564d688269d36c8"
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install shellcheck
+      run: |
+        curl -fsSLO https://github.com/koalaman/shellcheck/releases/download/${VERSION}/shellcheck-${VERSION}.linux.x86_64.tar.xz && \
+          echo "${SHA256_HASH}  shellcheck-${VERSION}.linux.x86_64.tar.xz" | sha256sum -c && \
+          tar -xf shellcheck-${VERSION}.linux.x86_64.tar.xz && \
+          sudo mv shellcheck-${VERSION}/shellcheck /usr/local/bin && \
+          rm -fr shellcheck-${VERSION} shellcheck-${VERSION}.linux.x86_64.tar.xz
+    - name: Run shellcheck
+      run: |
+        find . -type f -name '*.sh' | xargs shellcheck

--- a/.github/workflows/yapf.yml
+++ b/.github/workflows/yapf.yml
@@ -18,7 +18,7 @@ jobs:
       shell: bash -l {0}
       run: |
         pip install yapf
-    - name: run yapf
+    - name: Run yapf
       shell: bash -l {0}
       run: |
         yapf -r --diff .

--- a/docker/scripts/docker_run.sh
+++ b/docker/scripts/docker_run.sh
@@ -3,12 +3,12 @@
 # check that all required parameters are provided
 if [ $# -ne 3 ]
 then
-	  echo "usage: $0 IMAGE_NAME PORT ENV"
+	  echo "usage: ${0} IMAGE_NAME PORT ENV"
 	  echo "   where IMAGE_NAME is the image name and tage to use"
 	  echo "   where PORT is the local port number where to map the port of the server on the container"
 	  echo "   where ENV can be dev, prod"
       echo ""
-      echo "   example: $0 icubam:1.0 9000 dev"
+      echo "   example: ${0} icubam:1.0 9000 dev"
 	  exit
 fi
 
@@ -32,16 +32,16 @@ if [ ! -f "$(pwd)"/test.db ]; then
 fi
 
 
-docker run -d -p $2:8888 \
+docker run -d -p "${2}":8888 \
     --name icubam-server \
     --mount type=bind,source="$(pwd)"/resources/config.toml,target=/home/icubam/resources/config.toml \
     --mount type=bind,source="$(pwd)"/icubam.db,target=/home/icubam/icubam.db \
     --mount type=bind,source="$(pwd)"/test.db,target=/home/icubam/test.db \
-    --env ENV_MODE=$3 \
-    --env SECRET_COOKIE=$SECRET_COOKIE \
-    --env JWT_SECRET=$JWT_SECRET \
-    --env GOOGLE_API_KEY=$GOOGLE_API_KEY \
-    --env TW_KEY=$TW_KEY \
-    --env TW_API=$TW_API \
-     $1  \
+    --env ENV_MODE="${3}" \
+    --env SECRET_COOKIE="${SECRET_COOKIE}" \
+    --env JWT_SECRET="${JWT_SECRET}" \
+    --env GOOGLE_API_KEY="${GOOGLE_API_KEY}" \
+    --env TW_KEY="${TW_KEY}" \
+    --env TW_API="${TW_API}" \
+    "${1}" \
     ./start_server.sh

--- a/docker/scripts/docker_run_bo.sh
+++ b/docker/scripts/docker_run_bo.sh
@@ -3,12 +3,12 @@
 # check that all required parameters are provided
 if [ $# -ne 3 ]
 then
-	  echo "usage: $0 IMAGE_NAME PORT ENV"
+	  echo "usage: ${0} IMAGE_NAME PORT ENV"
 	  echo "   where IMAGE_NAME is the image name and tage to use"
 	  echo "   where PORT is the local port number where to map the port of the server on the container"
 	  echo "   where ENV can be dev, prod"
       echo ""
-      echo "   example: $0 icubam:1.0 9000 dev"
+      echo "   example: ${0} icubam:1.0 9000 dev"
 	  exit
 fi
 
@@ -32,16 +32,16 @@ if [ ! -f "$(pwd)"/test.db ]; then
 fi
 
 
-docker run -d -p $2:8890 \
+docker run -d -p "${2}":8890 \
     --name icubam-bo \
     --mount type=bind,source="$(pwd)"/resources/config.toml,target=/home/icubam/resources/config.toml \
     --mount type=bind,source="$(pwd)"/icubam.db,target=/home/icubam/icubam.db \
     --mount type=bind,source="$(pwd)"/test.db,target=/home/icubam/test.db \
-    --env ENV_MODE=$3 \
-    --env SECRET_COOKIE=$SECRET_COOKIE \
-    --env JWT_SECRET=$JWT_SECRET \
-    --env GOOGLE_API_KEY=$GOOGLE_API_KEY \
-    --env TW_KEY=$TW_KEY \
-    --env TW_API=$TW_API \
-     $1  \
+    --env ENV_MODE="${3}" \
+    --env SECRET_COOKIE="${SECRET_COOKIE}" \
+    --env JWT_SECRET="${JWT_SECRET}" \
+    --env GOOGLE_API_KEY="${GOOGLE_API_KEY}" \
+    --env TW_KEY="${TW_KEY}" \
+    --env TW_API="${TW_API}" \
+    "${1}" \
     ./start_server_bo.sh

--- a/docker/scripts/docker_sms_run.sh
+++ b/docker/scripts/docker_sms_run.sh
@@ -3,11 +3,11 @@
 # check that all required parameters are provided
 if [ $# -ne 2 ]
 then
-	  echo "usage: $0 IMAGE_NAME ENV"
+	  echo "usage: ${0} IMAGE_NAME ENV"
 	  echo "   where IMAGE_NAME is the image name and tage to use"
 	  echo "   where ENV can be dev, prod"
       echo ""
-      echo "   example: $0 icubam:1.0 dev"
+      echo "   example: ${0} icubam:1.0 dev"
 	  exit
 fi
 
@@ -29,11 +29,11 @@ docker run -dt \
     --mount type=bind,source="$(pwd)"/resources/config.toml,target=/home/icubam/resources/config.toml \
     --mount type=bind,source="$(pwd)"/icubam.db,target=/home/icubam/icubam.db \
     --mount type=bind,source="$(pwd)"/test.db,target=/home/icubam/test.db \
-    --env ENV_MODE=$2
-    --env SECRET_COOKIE=$SECRET_COOKIE \
-    --env JWT_SECRET=$JWT_SECRET \
-    --env GOOGLE_API_KEY=$GOOGLE_API_KEY \
-    --env TW_KEY=$TW_KEY \
-    --env TW_API=$TW_API \
-    $1  \
+    --env ENV_MODE="${2}" \
+    --env SECRET_COOKIE="${SECRET_COOKIE}" \
+    --env JWT_SECRET="${JWT_SECRET}" \
+    --env GOOGLE_API_KEY="${GOOGLE_API_KEY}" \
+    --env TW_KEY="${TW_KEY}" \
+    --env TW_API="${TW_API}" \
+    "${1}" \
     ./start_server_sms.sh

--- a/docker/scripts/set_hostname_nginx.sh
+++ b/docker/scripts/set_hostname_nginx.sh
@@ -2,23 +2,23 @@
 
 if [ $# -ne 1 ]
 then
-	  echo "usage: $0 HOSTNAME"
+	  echo "usage: ${0} HOSTNAME"
 	  echo "   where HOSTNAME is the Internet hostname to validate with Let's Encrypt/Certbot"
       echo ""
-      echo "   example: $0 www.example.org"
+      echo "   example: ${0} www.example.org"
 	  exit
 fi
 
-echo "Replace all occurences of WEB_HOSTNAME in nginx config file with $1"
+echo "Replace all occurences of WEB_HOSTNAME in nginx config file with ${1}"
 
 for f in ../configs/nginx/* ; do
-  if [ -f $f ]; then
-    echo "Process $f"
+  if [ -f "${f}" ]; then
+    echo "Process ${f}"
     if [[ "$OSTYPE" == "linux-gnu" ]]; then
-      sed -i 's|WEB_HOSTNAME|'"$1"'|g' $f;
+      sed -i 's|WEB_HOSTNAME|'"$1"'|g' "${f}";
     elif [[ "$OSTYPE" == "darwin"* ]]; then
       # empty extension required on MacOSX
-      sed -i '' 's|WEB_HOSTNAME|'"$1"'|g' $f;
+      sed -i '' 's|WEB_HOSTNAME|'"$1"'|g' "${f}";
     fi
   fi
 done

--- a/docker/start_server.sh
+++ b/docker/start_server.sh
@@ -6,5 +6,5 @@ conda init bash
 conda activate icubam
 
 # launch the server
-echo "launch icubam server in mode $ENV_MODE"
-python3 scripts/run_server.py --port 8888 --mode=$ENV_MODE --config=/home/icubam/resources/config.toml
+echo "launch icubam server in mode ${ENV_MODE}"
+python3 scripts/run_server.py --port 8888 --mode="${ENV_MODE}" --config=/home/icubam/resources/config.toml

--- a/docker/start_server_bo.sh
+++ b/docker/start_server_bo.sh
@@ -6,5 +6,5 @@ conda init bash
 conda activate icubam
 
 # launch the server
-echo "launch back-office server in mode $ENV_MODE"
-python3 scripts/run_server.py --mode=$ENV_MODE --server=backoffice
+echo "launch back-office server in mode ${ENV_MODE}"
+python3 scripts/run_server.py --mode="${ENV_MODE}" --server=backoffice

--- a/docker/start_server_sms.sh
+++ b/docker/start_server_sms.sh
@@ -6,5 +6,5 @@ conda init bash
 conda activate icubam
 
 # launch the server
-echo "launch sms server in mode $ENV_MODE"
-python3 scripts/schedule_sms.py --mode=$ENV_MODE --config=/home/icubam/resources/config.toml
+echo "launch sms server in mode ${ENV_MODE}"
+python3 scripts/schedule_sms.py --mode="${ENV_MODE}" --config=/home/icubam/resources/config.toml


### PR DESCRIPTION
### Why?

To help find bugs early and enforce standards & best practices.
(Since `yapf` was added recently, I thought this would be one more step in that direction. Feel free to close if undesirable for whatever reason, though. 🙂)

### What?

- Lint shell scripts as part of CI.
- Fix all warnings raised by `shellcheck`:

  ```console
  find . -type f -name '*.sh' | xargs spellcheck
  ```

    - SC2086: https://github.com/koalaman/shellcheck/wiki/SC2086
    - SC2215: https://github.com/koalaman/shellcheck/wiki/SC2215
    - SC2162: https://github.com/koalaman/shellcheck/wiki/SC2162
    - SC2128: https://github.com/koalaman/shellcheck/wiki/SC2128
