### PR TITLE
Fix #251: /list_tokens HTTP 500

### DIFF
--- a/icubam/backoffice/handlers/base.py
+++ b/icubam/backoffice/handlers/base.py
@@ -35,7 +35,8 @@ class BaseHandler(tornado.web.RequestHandler):
 
   def render_list(self, data, objtype, create_handler=None, **kwargs):
     route = None if create_handler is None else create_handler.ROUTE
-    columns = json.dumps([x['key'] for x in data[0]])
+    item = data[0] if data else []
+    columns = json.dumps([x['key'] for x in item])
     return self.render(
       "list.html",
       data=data,


### PR DESCRIPTION
IIUC, https://github.com/icubam/icubam/commit/fd464da6504be58302fa8d6132802088bacac807 is trying to extract column names from the first item in data passed to `render_list`, which fails if the data is empty.

I believe this fix should restore previous behavior on empty lists.

I haven't explored the testing infrastructure yet, so I'm not sure how to add a regression test. Any guidance welcome.

Fixes #251.