### PR TITLE
Please yapf: icubam/backoffice/handlers/base.py

### DIFF
--- a/icubam/backoffice/handlers/base.py
+++ b/icubam/backoffice/handlers/base.py
@@ -24,12 +24,7 @@ class BaseHandler(tornado.web.RequestHandler):
     # This dictionary is updated by a PeriodicCallback in the
     # BackofficeApplication
     status = self.application.server_status
-    super().render(
-      path,
-      root=self.root_path,
-      server_status=status,
-      **kwargs
-    )
+    super().render(path, root=self.root_path, server_status=status, **kwargs)
 
   def render_list(self, data, objtype, create_handler=None, **kwargs):
     route = None if create_handler is None else create_handler.ROUTE


### PR DESCRIPTION
### Why?

CI is [currently failing](https://github.com/icubam/icubam/pull/249/checks?check_run_id=585221737#step:5:20) with:

```console
yapf -r --diff .
--- ./icubam/backoffice/handlers/base.py	(original)
+++ ./icubam/backoffice/handlers/base.py	(reformatted)
@@ -24,12 +24,7 @@
     # This dictionary is updated by a PeriodicCallback in the
     # BackofficeApplication
     status = self.application.server_status
-    super().render(
-      path,
-      root=self.root_path,
-      server_status=status,
-      **kwargs
-    )
+    super().render(path, root=self.root_path, server_status=status, **kwargs)

   def render_list(self, data, objtype, create_handler=None, **kwargs):
     route = None if create_handler is None else create_handler.ROUTE
```

### What?

This PR applies the above change in order to please `yapf`, and have CI working again.
