### PR TITLE
TST Fix /operational-dashboard BO tests

### DIFF
--- a/icubam/backoffice/handlers/operational_dashboard.py
+++ b/icubam/backoffice/handlers/operational_dashboard.py
@@ -15,7 +15,7 @@ from bokeh.plotting import figure
 from bokeh.transform import dodge
 from bokeh.models import ColumnDataSource
 
-from icubam.db.store import to_pandas
+from icubam.db.store import to_pandas, BedCount
 from icubam.backoffice.handlers import base
 
 
@@ -170,8 +170,14 @@ class OperationalDashHandler(base.AdminHandler):
     bed_counts = self.db.get_visible_bed_counts_for_user(
       self.current_user.user_id
     )
-
-    bed_counts = to_pandas(bed_counts)
+    if bed_counts:
+      bed_counts = to_pandas(bed_counts)
+    else:
+      # when no data, make sure the resulting dataframe has
+      # correct column names.
+      columns = [key for key in dir(BedCount) if not key.startswith('_')]
+      columns += ['icu_dept']
+      bed_counts = pd.DataFrame([], columns=columns)
 
     if current_region is not None:
       mask = bed_counts['icu_region_id'] == current_region.region_id

--- a/icubam/backoffice/server_test.py
+++ b/icubam/backoffice/server_test.py
@@ -59,8 +59,7 @@ class ServerTestCase(tornado.testing.AsyncHTTPTestCase):
       regions.ListRegionsHandler,
       regions.RegionHandler,
       bedcounts.ListBedCountsHandler,
-      #TODO this test fails (see below)
-      #operational_dashboard.OperationalDashHandler,
+      operational_dashboard.OperationalDashHandler,
       #TODO this test fails, probably because the message server is not started
       #messages.ListMessagesHandler,
       maps.MapsHandler,
@@ -73,9 +72,6 @@ class ServerTestCase(tornado.testing.AsyncHTTPTestCase):
 
   def test_operational_dashboard(self):
     handler = operational_dashboard.OperationalDashHandler
-    # TODO: The following fails only in tests for some reason.
-    # Manyally tested, skiping this test for now.
-    raise SkipTest
     with mock.patch.object(base.BaseHandler, 'get_current_user') as m:
       m.return_value = self.user
       response = self.fetch(handler.ROUTE + '?region=1', method='GET')


### PR DESCRIPTION
Following https://github.com/icubam/icubam/pull/256 fixes  /operational-dashboard BO tests

Also helps for https://github.com/icubam/icubam/issues/197


Whether there should be data in get_visible_bed_counts_for_user is this test also a good question. Maybe we should run this test for admin and non admin user.  In any case not failing when the query returns no results cannot hurt.