### PR TITLE
Re-enable codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,21 @@
+comment: false
+
+coverage:
+  status:
+    project:
+      default:
+        # Commits pushed to master should not make the overall
+        # project coverage decrease by more than 4%:
+        target: auto
+        threshold: 4%
+    patch:
+      default:
+        # Be tolerant on code coverage diff on PRs to limit
+        # noisy red coverage status on github PRs.
+        # Note The coverage stats are still uploaded
+        # to codecov so that PR reviewers can see uncovered lines
+        # in the github diff if they install the codecov browser
+        # extension:
+        # https://github.com/codecov/browser-extension
+        target: auto
+        threshold: 50%

--- a/.github/workflows/pythontest-linux.yml
+++ b/.github/workflows/pythontest-linux.yml
@@ -42,7 +42,7 @@ jobs:
         pip install pytest-cov
         pip install -e .
         pytest --cov=icubam --cov-report=xml --cov-report=html
-#    - name: "Upload coverage to Codecov"
-#      uses: "codecov/codecov-action@v1"
-#      with:
-#        fail_ci_if_error: false
+    - name: "Upload coverage to Codecov"
+      uses: "codecov/codecov-action@v1"
+      with:
+        fail_ci_if_error: false


### PR DESCRIPTION
Re-enable codecov to be a little less strict. In particular, no matter the coverage report it should not fail the CI and thus prevent merge.