### PR TITLE
Take legal_id into account when importing from CSV

### DIFF
--- a/icubam/db/synchronizer.py
+++ b/icubam/db/synchronizer.py
@@ -13,9 +13,18 @@ from icubam.db import store
 # value, however columns that are used to create joins such as icu_name or
 # ICU_COLUMNS['name'] will throw an error if they are None or not aligned with
 # existing elements in the store.
-ICU_COLUMNS = [
-  'name', 'legal_id', 'dept', 'city', 'region', 'country', 'lat', 'long', 'telephone'
-]
+ICU_DTYPE = {
+  'name': 'string',
+  'legal_id': 'string',
+  'country': 'string',
+  'region': 'string',
+  'dept': 'string',
+  'city': 'string',
+  'lat': 'string',
+  'long': 'string',
+  'telephone': 'string'
+}
+ICU_COLUMNS = list(ICU_DTYPE.keys())
 USER_COLUMNS = ['icu_name', 'name', 'telephone', 'description']
 BC_COLUMNS = [
   'icu_name', 'n_covid_occ', 'n_covid_free', 'n_ncovid_occ', 'n_ncovid_free',

--- a/icubam/db/synchronizer.py
+++ b/icubam/db/synchronizer.py
@@ -13,7 +13,9 @@ from icubam.db import store
 # value, however columns that are used to create joins such as icu_name or
 # ICU_COLUMNS['name'] will throw an error if they are None or not aligned with
 # existing elements in the store.
-ICU_COLUMNS = ['name', 'region', 'dept', 'city', 'lat', 'long', 'telephone']
+ICU_COLUMNS = [
+  'name', 'region', 'dept', 'city', 'lat', 'long', 'telephone', 'legal_id'
+]
 USER_COLUMNS = ['icu_name', 'name', 'telephone', 'description']
 BC_COLUMNS = [
   'icu_name', 'n_covid_occ', 'n_covid_free', 'n_ncovid_occ', 'n_ncovid_free',

--- a/icubam/db/synchronizer.py
+++ b/icubam/db/synchronizer.py
@@ -14,7 +14,7 @@ from icubam.db import store
 # ICU_COLUMNS['name'] will throw an error if they are None or not aligned with
 # existing elements in the store.
 ICU_COLUMNS = [
-  'name', 'region', 'dept', 'city', 'lat', 'long', 'telephone', 'legal_id'
+  'name', 'legal_id', 'dept', 'city', 'region', 'country', 'lat', 'long', 'telephone'
 ]
 USER_COLUMNS = ['icu_name', 'name', 'telephone', 'description']
 BC_COLUMNS = [

--- a/resources/test/icu.csv
+++ b/resources/test/icu.csv
@@ -1,4 +1,4 @@
-name,region,dept,city,lat,long,telephone,legal_id
-hopital1,nord,limousin,san diego,49.7783,4.7198,11,123
-hopital2,sud,poitou,pekin,54.7783,5.7198,22,
-hopital3,est,ardennes,rio,62.7783,6.7198,33,56498787
+name,region,dept,city,lat,long,telephone,legal_id,country
+hopital1,nord,limousin,san diego,49.7783,4.7198,11,123,FR
+hopital2,sud,poitou,pekin,54.7783,5.7198,22,FR
+hopital3,est,ardennes,rio,62.7783,6.7198,33,56498787,US

--- a/resources/test/icu.csv
+++ b/resources/test/icu.csv
@@ -1,4 +1,4 @@
-name,region,dept,city,lat,long,telephone
-hopital1,nord,limousin,san diego,49.7783,4.7198,11
-hopital2,sud,poitou,pekin,54.7783,5.7198,22
-hopital3,est,ardennes,rio,62.7783,6.7198,33
+name,region,dept,city,lat,long,telephone,legal_id
+hopital1,nord,limousin,san diego,49.7783,4.7198,11,123
+hopital2,sud,poitou,pekin,54.7783,5.7198,22,
+hopital3,est,ardennes,rio,62.7783,6.7198,33,56498787

--- a/resources/test/icu2.csv
+++ b/resources/test/icu2.csv
@@ -1,5 +1,5 @@
-name,region,dept,city,lat,long,telephone
-hopital1,nord,limousin,san diego,49.7783,4.7198,99
-hopital2,sud,poitou,pekin,54.7783,5.7198,22
-hopital3,est,ardennes,rio,62.7783,6.7198,33
-hopital4,ouest,nord,london,82.7783,7.7198,44
+name,region,dept,city,lat,long,telephone,legal_id
+hopital1,nord,limousin,san diego,49.7783,4.7198,99,8347
+hopital2,sud,poitou,pekin,54.7783,5.7198,22,
+hopital3,est,ardennes,rio,62.7783,6.7198,33,983274
+hopital4,ouest,nord,london,82.7783,7.7198,44,98347

--- a/resources/test/icu2.csv
+++ b/resources/test/icu2.csv
@@ -1,5 +1,5 @@
-name,region,dept,city,lat,long,telephone,legal_id
-hopital1,nord,limousin,san diego,49.7783,4.7198,99,8347
-hopital2,sud,poitou,pekin,54.7783,5.7198,22,
-hopital3,est,ardennes,rio,62.7783,6.7198,33,983274
-hopital4,ouest,nord,london,82.7783,7.7198,44,98347
+name,region,dept,city,lat,long,telephone,legal_id,country
+hopital1,nord,limousin,san diego,49.7783,4.7198,99,8347,FR
+hopital2,sud,poitou,pekin,54.7783,5.7198,22,GR
+hopital3,est,ardennes,rio,62.7783,6.7198,33,983274,FR
+hopital4,ouest,nord,london,82.7783,7.7198,44,98347,US


### PR DESCRIPTION
This is a lighter version of #291, because @dulacarnold needs to quickly update FINESS numbers on the production server.

We only add parsing of the `legal_id` column in CSV files, without all the machinery for looking up FINESS data, that #291 does.