### PR TITLE
STY Revert isort force_single_line=True

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,5 @@
 [build-system]
 requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4"]
 
-[tool.isort]
-force_single_line = true
-
 # enable versionning with setuptools_scm
 [tool.setuptools_scm]


### PR DESCRIPTION
Sorry @dulacarnold I haven't realized what force_single_line=True does in isort (https://github.com/icubam/icubam/pull/315).

I don't find that,
```py
from typing import Dict, List, Optional
```
needs to be changed to,
```py
from typing import Dict
from typing import List
from typing import Optional
```
it's very verbose.