### PR TITLE
Fix type errors and add mypy check

### DIFF
--- a/.github/workflows/pythontest-linux.yml
+++ b/.github/workflows/pythontest-linux.yml
@@ -41,7 +41,7 @@ jobs:
         pip --version
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install pytest pytest-cov
+        pip install pytest pytest-cov mypy
     - name: Test with pytest
       env:
         JWT_SECRET: faketest
@@ -49,6 +49,10 @@ jobs:
         set -x
         pip install -e .
         pytest --cov=icubam --cov-report=xml --cov-report=html
+    - name: Typecheck with mypy
+      run: |
+        set -ex
+        mypy -p icubam --ignore-missing-imports
     - name: "Upload coverage to Codecov"
       uses: "codecov/codecov-action@v1"
       with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,11 @@
       args: [-c]
       types: [file,python]
       additional_dependencies: [toml]
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.730
+    hooks:
+     -  id: mypy
+        args:
+          - --ignore-missing-imports
+        files: icubam/
+        types: [file, python]

--- a/icubam/backoffice/handlers/base.py
+++ b/icubam/backoffice/handlers/base.py
@@ -2,7 +2,7 @@ import json
 import os.path
 import tornado.locale
 import tornado.web
-from typing import List, Dict, Union
+from typing import List, Dict, Union, Optional
 
 
 class BaseHandler(tornado.web.RequestHandler):
@@ -81,14 +81,16 @@ class BaseHandler(tornado.web.RequestHandler):
     """Given a store class, parse the body a dictionary."""
     result = dict()
     for col in cls.get_column_names():
-      value = self.get_body_arguments(col + '[]', None)
+      value: Union[
+        Optional[str],
+        List[str]] = self.get_body_arguments(col + '[]', strip=False)
       if not value:
         value = self.get_body_argument(col, None)
       if value is not None:
         result[col] = value
     return result
 
-  def format_list_item(self, item: Union[Dict, List]) -> list:
+  def format_list_item(self, item: Union[Dict, List]) -> Union[Dict, List]:
     """Prepare a dictionary representing a row of a table for display."""
     # TODO(olivier) improve this, too hard coded
     auto_links = {f'{k}_id': k for k in ['icu', 'user', 'region']}

--- a/icubam/backoffice/handlers/operational_dashboard.py
+++ b/icubam/backoffice/handlers/operational_dashboard.py
@@ -1,4 +1,4 @@
-from typing import List, Dict
+from typing import List, Tuple
 
 import os
 from pathlib import Path
@@ -17,7 +17,7 @@ from icubam.db.store import to_pandas, BedCount
 from icubam.backoffice.handlers import base
 
 
-def _prepare_data(bed_counts: List) -> Dict:
+def _prepare_data(bed_counts: pd.DataFrame) -> Tuple[pd.DataFrame, List]:
   """Make plot data"""
   agg_args = {
     key: 'sum'
@@ -27,7 +27,7 @@ def _prepare_data(bed_counts: List) -> Dict:
       'n_covid_transfered'
     ]
   }
-  df = bed_counts.groupby('icu_dept').agg(agg_args)
+  df: pd.DataFrame = bed_counts.groupby('icu_dept').agg(agg_args)
 
   df['total_capacity'] = df[[
     'n_covid_occ', 'n_covid_free', 'n_ncovid_occ', 'n_ncovid_free'
@@ -135,8 +135,8 @@ def _list_extra_plots(input_dir: Path) -> List[str]:
   if not input_dir.exists():
     return []
   out = []
-  for fpath in os.listdir(input_dir):
-    fpath = Path(fpath)
+  for s in os.listdir(input_dir):
+    fpath = Path(s)
     if fpath.suffix != '.png':
       continue
     out.append(fpath.stem)

--- a/icubam/backoffice/handlers/tokens.py
+++ b/icubam/backoffice/handlers/tokens.py
@@ -3,7 +3,7 @@ import datetime
 import os.path
 import tornado.escape
 import tornado.web
-from typing import Optional, Tuple, List
+from typing import Optional, Tuple, List, Set
 
 from icubam.backoffice.handlers import base
 from icubam.www.handlers import home as www_home
@@ -65,7 +65,7 @@ class TokenHandler(base.AdminHandler):
 
   def do_render(
     self,
-    user: Optional[store.User],
+    user: Optional[store.ExternalClient],
     regions: Optional[List[int]],
     error=False
   ):
@@ -114,7 +114,7 @@ class TokenHandler(base.AdminHandler):
         self.current_user.user_id, token_id, rid
       )
 
-  def prepare_for_save(self, token_dict) -> Tuple[int, List[int]]:
+  def prepare_for_save(self, token_dict) -> Tuple[int, Set[int]]:
     token_dict["is_active"] = token_dict.get("is_active", "off") == 'on'
     date = token_dict.get('expiration_date', '')
     if date == '':

--- a/icubam/backoffice/handlers/upload.py
+++ b/icubam/backoffice/handlers/upload.py
@@ -11,12 +11,12 @@ from icubam.db import synchronizer
 class UploadHandler(base.BaseHandler):
   ROUTE = "upload"
 
-  def answer(self, msg, error=False):
+  def answer(self, msg, error=False) -> None:
     logging.error(msg)
     self.write(json.dumps({'msg': msg, 'error': error}))
 
   @tornado.web.authenticated
-  def post(self):
+  def post(self) -> None:
     try:
       data = json.loads(self.request.body.decode())
     except Exception as e:
@@ -30,7 +30,7 @@ class UploadHandler(base.BaseHandler):
     sync_fns = {
       'user': sync.sync_users_from_csv,
       'icu': sync.sync_icus_from_csv,
-      'bedcounts': sync.sync_bedcount_from_csv
+      'bedcounts': sync.sync_bedcounts_from_csv
     }
     objtype = data.get('objtype', None)
     sync_fn = sync_fns.get(objtype, None)

--- a/icubam/backoffice/server.py
+++ b/icubam/backoffice/server.py
@@ -2,6 +2,7 @@ import collections
 import dataclasses
 import datetime
 import os.path
+from typing import Optional
 
 import tornado.ioloop
 import tornado.locale
@@ -27,10 +28,10 @@ from icubam.backoffice.handlers import users
 
 @dataclasses.dataclass
 class ServerStatus:
-  name: int = None
-  up: bool = None
-  started: str = None
-  last_ping: datetime.datetime = None
+  name: Optional[int] = None
+  up: Optional[bool] = None
+  started: Optional[str] = None
+  last_ping: Optional[datetime.datetime] = None
 
 
 class BackofficeApplication(tornado.web.Application):

--- a/icubam/db/synchronizer.py
+++ b/icubam/db/synchronizer.py
@@ -222,9 +222,7 @@ class CSVPreprocessor(CSVSynchronizer):
     'NBR_LIT_INS': 'n_covid_tot'
   }
 
-  def sync_bedcounts_ror_idf(
-    self, csv_contents: TextIO, user=None, force_update=False
-  ):
+  def sync_bedcounts_ror_idf(self, csv_contents: TextIO, user=None):
     """Sync bedcount CSVs from IdF RoR uplink."""
     bedcounts_df = pd.read_csv(csv_contents)
     col_diff = set(self.ROR_COLUMNS_MAP.keys()) - set(bedcounts_df.columns)
@@ -244,4 +242,4 @@ class CSVPreprocessor(CSVSynchronizer):
     bc['create_date'] = pd.to_datetime(
       bc['create_date']
     ).dt.tz_localize("Europe/Paris").dt.tz_convert(tz.tzutc())
-    self.sync_bed_counts(bc, user, force_update)
+    self.sync_bed_counts(bc, user)

--- a/icubam/map_builder.py
+++ b/icubam/map_builder.py
@@ -64,7 +64,10 @@ class MapBuilder:
     level: str = 'dept',
   ):
     data = {}
-    anchor = center_icu
+    center = {
+      'lat': center_icu.lat,
+      'lng': center_icu.long
+    } if center_icu else None
     for covid in [True, False]:
       tree = icu_tree.ICUTree(covid=covid)
       icus = self.db.get_icus()
@@ -72,8 +75,7 @@ class MapBuilder:
         icus = [icu for icu in icus if icu.region_id in regions]
       tree.add_many(icus, self.db.get_latest_bed_counts())
       data[covid] = self.to_map_data(tree, level)
+      if center is None:
+        center = {'lat': tree.lat, 'lng': tree.long}
 
-      if anchor is None:
-        anchor = tree
-    center = {'lat': anchor.lat, 'lng': anchor.long}
     return json.dumps(data), json.dumps(center)

--- a/icubam/messaging/handlers/schedule.py
+++ b/icubam/messaging/handlers/schedule.py
@@ -2,7 +2,7 @@ from absl import logging
 import dataclasses
 import json
 import tornado.web
-from typing import List, Tuple
+from typing import List, Tuple, Optional
 
 from icubam.messaging import message
 from icubam.messaging import serializable
@@ -10,20 +10,20 @@ from icubam.messaging import serializable
 
 @dataclasses.dataclass
 class ScheduleRequest(serializable.Serizalizable):
-  user_id: int = None
+  user_id: Optional[int] = None
 
 
 @dataclasses.dataclass
 class ScheduledMessage:
-  icu_id: int = None
-  user_id: int = None
-  user_name: str = None
-  icu_name: str = None
-  phone: str = None
-  attempts: int = 0
-  first_sent: int = None
-  when: int = None
-  url: str = None
+  icu_id: Optional[int] = None
+  user_id: Optional[int] = None
+  user_name: Optional[str] = None
+  icu_name: Optional[str] = None
+  phone: Optional[str] = None
+  attempts: Optional[int] = 0
+  first_sent: Optional[int] = None
+  when: Optional[int] = None
+  url: Optional[str] = None
 
 
 class ScheduleHandler(tornado.web.RequestHandler):

--- a/icubam/predicu/data.py
+++ b/icubam/predicu/data.py
@@ -20,7 +20,7 @@ DATA_PATHS = {
 }
 
 for key, path in DATA_PATHS.items():
-  DATA_PATHS[key] = Path(BASE_PATH) / path
+  DATA_PATHS[key] = str(Path(BASE_PATH) / path)
 
 
 def load_department_population():

--- a/icubam/predicu/plot/__init__.py
+++ b/icubam/predicu/plot/__init__.py
@@ -103,8 +103,8 @@ def plot(
   cached_data: Dict[str, pd.DataFrame],
   output_dir: str,
   output_type: str,
-  api_key: str,
-  icubam_host: str,
+  api_key: Optional[str],
+  icubam_host: Optional[str],
   matplotlib_style: str,
 ):
   plot_module = __import__(f"{plot_name}", globals(), locals(), ["plot"], 1)

--- a/icubam/www/handlers/base.py
+++ b/icubam/www/handlers/base.py
@@ -2,7 +2,7 @@ from absl import logging
 import os.path
 import tornado.locale
 import tornado.web
-from typing import Tuple
+from typing import Tuple, Optional
 
 from icubam.db import store
 from icubam.www import token
@@ -20,7 +20,9 @@ class BaseHandler(tornado.web.RequestHandler):
     self.user = None
     self.token_encoder = token.TokenEncoder(self.config)
 
-  def decode_token(self, user_token: str) -> Tuple[store.User, store.ICU]:
+  def decode_token(
+    self, user_token: str
+  ) -> Tuple[Optional[store.User], Optional[store.ICU]]:
     """Returns the user object and the icu object encoded in the token."""
     input_data = self.token_encoder.decode(user_token)
     if input_data is None:

--- a/icubam/www/updater.py
+++ b/icubam/www/updater.py
@@ -25,8 +25,9 @@ class Updater:
 
   def get_user_url(self, user, icu_id: str) -> str:
     icu = {i.icu_id: i for i in user.icus}.get(icu_id, None)
-    if icu is not None:
-      return self.get_url(user, icu)
+    if icu is None:
+      raise ValueError(f"Cannot find ICU {icu_id} for user")
+    return self.get_url(user, icu)
 
   def get_url(self, user, icu) -> str:
     return "{}{}?id={}".format(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 yapf
 pre-commit
 flake8
+mypy


### PR DESCRIPTION
I saw some code on master (probably now in prod) with typos in method names. I believe we really need something that catches such errors systematically before merge.

So this PR is fixing existing type errors on the code base and adding `mypy` to CI. The next step will be to add more type annotations, but the good thing is that it can be done incrementally.

Closes #180.