### PR TITLE
Fix CSV import of bedcounts and add test

### DIFF
--- a/icubam/backoffice/handlers/upload.py
+++ b/icubam/backoffice/handlers/upload.py
@@ -6,6 +6,7 @@ import tornado.web
 
 from icubam.backoffice.handlers import base
 from icubam.db import synchronizer
+from typing import Dict, Callable
 
 
 class UploadHandler(base.BaseHandler):
@@ -27,7 +28,7 @@ class UploadHandler(base.BaseHandler):
       return self.answer(f'No CSV content', error=True)
 
     sync = synchronizer.CSVSynchronizer(self.db)
-    sync_fns = {
+    sync_fns: Dict[str, Callable[..., int]] = {
       'user': sync.sync_users_from_csv,
       'icu': sync.sync_icus_from_csv,
       'bedcounts': sync.sync_bedcounts_from_csv

--- a/icubam/db/test_synchronizer.py
+++ b/icubam/db/test_synchronizer.py
@@ -236,3 +236,11 @@ class CSVTest(absltest.TestCase):
       str_buf.splitlines(),
       len(icus) + 1, "Number of rows should be the same."
     )
+
+  def test_import_bedcounts(self):
+    with open("resources/test/icu2.csv") as csv_f:
+      self.csv.sync_icus_from_csv(csv_f, False)
+    with open("resources/test/bedcounts.csv") as csv_f:
+      self.csv.sync_bedcounts_from_csv(csv_f, False, timezone="Europe/Paris")
+    bed_counts = self.db.get_latest_bed_counts()
+    self.assertEqual(bed_counts[0].n_covid_free, 12)

--- a/resources/test/bedcounts.csv
+++ b/resources/test/bedcounts.csv
@@ -1,0 +1,2 @@
+icu_name,n_covid_occ,n_covid_free,n_ncovid_occ,n_ncovid_free,n_covid_deaths,n_covid_healed,n_covid_refused,n_covid_transfered,create_date
+hopital3,11,12,13,14,15,16,17,18,2020-04-16 23:00


### PR DESCRIPTION
The importer was calling `sync_users` instead of `sync_bedcounts`. We
also fix parsing of dates and add a test for this importer.