### PR TITLE
FIX Disable the check of None user_id in get_visible_bed_counts_for_user

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,13 @@
     rev: 3.7.9
     hooks:
     - id: flake8 
+-   repo: https://github.com/timothycrosley/isort
+    rev: 4.3.21-2
+    hooks: 
+    - id: isort
+      args: [-c]
+      types: [file,python]
+      additional_dependencies: [toml]
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.730
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,13 +6,6 @@
     rev: 3.7.9
     hooks:
     - id: flake8 
--   repo: https://github.com/timothycrosley/isort
-    rev: 4.3.21-2
-    hooks: 
-    - id: isort
-      args: [-c]
-      types: [file,python]
-      additional_dependencies: [toml]
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.730
     hooks:

--- a/icubam/db/store.py
+++ b/icubam/db/store.py
@@ -755,8 +755,14 @@ class Store(object):
 
     kargs are passed to get_latest_bed_counts_for_icus() method for additional
     filtering, e.g. max_date.
+
+    Args:
+      user_id: run query for a given user
+      force: run query as admin irrespective of the user_id
     """
     user = self.get_user(user_id)
+    if not force and user is None:
+      raise ValueError("A non null user_id must be provided")
     if force or user.is_admin:
       return self._get_bed_counts_for_icus(None, latest=True, **kargs)
     else:

--- a/icubam/db/store.py
+++ b/icubam/db/store.py
@@ -757,8 +757,6 @@ class Store(object):
     filtering, e.g. max_date.
     """
     user = self.get_user(user_id)
-    if not user:
-      raise ValueError(f"Cannot find user with id {user_id}")
     if force or user.is_admin:
       return self._get_bed_counts_for_icus(None, latest=True, **kargs)
     else:

--- a/icubam/db/store.py
+++ b/icubam/db/store.py
@@ -764,7 +764,7 @@ class Store(object):
     if force:
       return self._get_bed_counts_for_icus(None, latest=True, **kargs)
     elif user is None:
-      raise ValueError("a non null user_id must be provided")
+      raise ValueError(f"Cannot find user with id {user_id}.")
     elif user.is_admin:
       return self._get_bed_counts_for_icus(None, latest=True, **kargs)
     else:

--- a/icubam/db/store.py
+++ b/icubam/db/store.py
@@ -761,9 +761,11 @@ class Store(object):
       force: run query as admin irrespective of the user_id
     """
     user = self.get_user(user_id)
-    if not force and user is None:
-      raise ValueError("A non null user_id must be provided")
-    if force or user.is_admin:
+    if force:
+      return self._get_bed_counts_for_icus(None, latest=True, **kargs)
+    elif user is None:
+      raise ValueError("a non null user_id must be provided")
+    elif user.is_admin:
       return self._get_bed_counts_for_icus(None, latest=True, **kargs)
     else:
       icu_ids = set()

--- a/icubam/db/test_store.py
+++ b/icubam/db/test_store.py
@@ -513,7 +513,7 @@ class StoreTest(absltest.TestCase):
 
     # When force=False, user_id=None is invalid
     with self.assertRaisesRegex(
-      ValueError, 'non null user_id must be provided'
+      ValueError, "Cannot find user with id None"
     ):
       get_values(user_id=None, force=False)
 

--- a/icubam/db/test_store.py
+++ b/icubam/db/test_store.py
@@ -508,6 +508,14 @@ class StoreTest(absltest.TestCase):
         ("icu3", now): 5,
       }
     )
+    # when force=True, user_id can be None.
+    get_values(user_id=None, force=True)
+
+    # When force=False, user_id=None is invalid
+    with self.assertRaisesRegex(
+      ValueError, 'non null user_id must be provided'
+    ):
+      get_values(user_id=None, force=False)
 
   def test_get_visible_bed_counts_in_same_region(self):
     store = self.store

--- a/icubam/db/test_store.py
+++ b/icubam/db/test_store.py
@@ -512,9 +512,7 @@ class StoreTest(absltest.TestCase):
     get_values(user_id=None, force=True)
 
     # When force=False, user_id=None is invalid
-    with self.assertRaisesRegex(
-      ValueError, "Cannot find user with id None"
-    ):
+    with self.assertRaisesRegex(ValueError, "Cannot find user with id None"):
       get_values(user_id=None, force=False)
 
   def test_get_visible_bed_counts_in_same_region(self):


### PR DESCRIPTION
Re-opens https://github.com/icubam/icubam/issues/180

The fix in https://github.com/icubam/icubam/issues/180 was not sufficient as it also needs to account for `force=True`. For now just revert it.