### PR TITLE
Disable isort pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,13 +6,6 @@
     rev: 3.7.9
     hooks:
     - id: flake8 
--   repo: https://github.com/timothycrosley/isort
-    rev: 4.3.21-2
-    hooks: 
-    - id: isort
-      args: [-c]
-      types: [file,python]
-      additional_dependencies: [toml]
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.730
     hooks:


### PR DESCRIPTION
Following earlier discussion due to conflicts between yapf and isort.
Manual usage is still encouraged.