### PR TITLE
Wipe using SQLAlchemy API + reset admin option

### DIFF
--- a/icubam/db/test_wipe.py
+++ b/icubam/db/test_wipe.py
@@ -8,26 +8,38 @@ from icubam.db.store import StoreFactory
 
 class WipeTest(absltest.TestCase):
   def setUp(self):
-    self.engine = create_engine("sqlite:///:memory:", echo=False)
-    store_factory = StoreFactory(self.engine)
+    store_factory = StoreFactory(
+      create_engine("sqlite:///:memory:", echo=True)
+    )
     self.store = store_factory.create()
     populate_store_fake(self.store)
 
   def test_wipe(self):
-    with self.engine.connect() as conn:
-      wipe_db(conn.connection, keep_beds=False)
-      users = list(self.store.get_users())
-      self.assertItemsEqual([user.name for user in users],
-                            itertools.repeat("Jean Dumont", len(users)))
-      self.assertItemsEqual([
-        user.email for user in users
-      ], itertools.repeat("jean.dumont@example.org", len(users)))
-      bed_counts = list(self.store.get_bed_counts(None))
-      self.assertItemsEqual([bc.n_covid_free for bc in bed_counts],
-                            itertools.repeat(2, len(bed_counts)))
+    wipe_db(self.store, keep_beds=False)
+    users = list(self.store.get_users())
+    self.assertItemsEqual([user.name for user in users],
+                          itertools.repeat("Jean Dumont", len(users)))
+    self.assertItemsEqual([
+      user.email for user in users
+    ], itertools.repeat("jean.dumont@example.org", len(users)))
+    bed_counts = list(self.store.get_bed_counts(None))
+    self.assertItemsEqual([bc.n_covid_free for bc in bed_counts],
+                          itertools.repeat(2, len(bed_counts)))
 
   def test_keep_beds(self):
-    with self.engine.connect() as conn:
-      wipe_db(conn.connection, keep_beds=True)
-      bed_counts = list(self.store.get_bed_counts(None))
-      self.assertFalse(all([bc.n_covid_free == 2 for bc in bed_counts]))
+    wipe_db(self.store, keep_beds=True)
+    bed_counts = list(self.store.get_bed_counts(None))
+    self.assertFalse(all([bc.n_covid_free == 2 for bc in bed_counts]))
+
+  def test_reset_admin(self):
+    email = "admin.test@example.org"
+    wipe_db(
+      self.store,
+      keep_beds=False,
+      reset_admin=True,
+      admin_email=email,
+      admin_pass="f00b4r"
+    )
+    admins = list(self.store.get_admins())
+    self.assertTrue(len(admins) == 1)
+    self.assertTrue(admins[0].email == email)

--- a/icubam/db/wipe.py
+++ b/icubam/db/wipe.py
@@ -1,49 +1,71 @@
+from icubam.db.store import BedCount, ExternalClient, ICU, User
+
 ALTERATIONS = {
-  "bed_counts": [
-    ("n_ncovid_free", 3),
-    ("n_ncovid_occ", 5),
-    ("n_covid_deaths", 0),
-    ("n_covid_healed", 0),
-    ("n_covid_refused", 0),
-    ("n_covid_transfered", 0),
-    ("message", '"Have a nice day!"'),
-  ],
-  "icus": [("telephone", "33120000000 + icus.icu_id")
-           ],  # we reuse the ID to respect telephone uniqueness constraint
-  "users": [
-    ("name", '"Jean Dumont"'),
-    ("email", '"jean.dumont@example.org"'),
-    ("telephone", "33600000001 + users.user_id"),
-    ("password_hash", 42),
-  ],
-  "external_clients": [
-    ("name", '"Jeanne Externe"'),
-    ("email", '"jeanne.externe@example.org"'),
-    ("telephone", "33600000001 + external_clients.external_client_id"),
-  ],
+  BedCount: {
+    "n_ncovid_free": 3,
+    "n_ncovid_occ": 5,
+    "n_covid_deaths": 0,
+    "n_covid_healed": 0,
+    "n_covid_refused": 0,
+    "n_covid_transfered": 0,
+    "message": "Have a nice day!",
+  },
+  ICU: {
+    "telephone": "33120000000"
+  },
+  User: {
+    "name": "Jean Dumont",
+    "email": "jean.dumont@example.org",
+    "telephone": "33600000001",
+    "password_hash": 42,
+  },
+  ExternalClient: {
+    "name": "Jeanne Externe",
+    "email": "jeanne.externe@example.org",
+    "telephone": "33600000001",
+  },
 }
 
 
-def wipe_db(conn, keep_beds):
+def wipe_db(
+  store, keep_beds, reset_admin=False, admin_email=None, admin_pass=None
+):
   """
   Wipe sensitive information from a database.
 
   Parameters
   ----------
-  conn: sqlite3 connection
+  store: icubam store
 
   keep_beds: bool
       True if bed information should be kept
+
+  reset_admin: bool
+      True if admins should be removed and a 'test' admin created.
+      If True, require admin_email and admin_pass to be set.
+
+  admin_email: str
+      Email of the newly-created admin user (if resetting admins)
+
+  admin_pass: str
+      Password of the newly-created admin user (if resetting admins)
 
   Returns
   -------
   None
   """
+
   if not keep_beds:
-    ALTERATIONS["bed_counts"].extend([("n_covid_free", 2), ("n_covid_occ", 4)])
+    ALTERATIONS[BedCount].update({"n_covid_free": 2, "n_covid_occ": 4})
   for alteration in ALTERATIONS.items():
-    affectations = ",".join([f"{k} = {v}" for (k, v) in alteration[1]])
-    query = f"UPDATE {alteration[0]} SET {affectations};"
-    conn.execute(query)
-  conn.commit()
-  conn.close()
+    store._session.query(alteration[0]).update(values=alteration[1])
+
+  if reset_admin:
+    if None in [admin_email, admin_pass]:
+      raise ValueError("admin_email and admin_pass must be defined")
+    store._session.query(User).filter(User.is_admin == True
+                                      ).update({'is_admin': False})
+    hash = store.get_password_hash(admin_pass)
+    store.add_user(
+      User(name="admin", email=admin_email, password_hash=hash, is_admin=True)
+    )

--- a/scripts/wipe_sensitive_info_db.py
+++ b/scripts/wipe_sensitive_info_db.py
@@ -6,22 +6,29 @@ Warning: modifies data in-place!
 from absl import app
 from absl import flags
 import click
-import sqlite3
+import os
+from sqlalchemy import create_engine
 
+from icubam.db.store import StoreFactory
 from icubam.db.wipe import wipe_db
 
 flags.DEFINE_boolean("force", False, "Do not prompt user confirmation.")
 flags.DEFINE_boolean(
   "keep_beds", False, "Whether to keep bed occupation data."
 )
+flags.DEFINE_boolean("reset_admin", False, "Reset admin information")
+flags.DEFINE_string("admin_email", None, "Admin email (if resetting admins)")
+flags.DEFINE_string("admin_pass", None, "Admin password (if resetting admins)")
 flags.DEFINE_string("filename", None, 'DB file name.')
 flags.mark_flag_as_required('filename')
 FLAGS = flags.FLAGS
 
 
-def wipe_db_path(path, keep_beds):
-  conn = sqlite3.connect(path)
-  wipe_db(conn, keep_beds)
+def wipe_db_path(path, keep_beds, reset_admin, admin_email, admin_pass):
+  store_factory = StoreFactory(create_engine("sqlite:///" + path))
+  wipe_db(
+    store_factory.create(), keep_beds, reset_admin, admin_email, admin_pass
+  )
 
 
 def main(argv):
@@ -30,7 +37,10 @@ def main(argv):
       "WARNING: THIS WILL WIPE THE DATABASE IN-PLACE. CONTINUE?", err=True
     ):
       return
-  wipe_db_path(FLAGS.filename, FLAGS.keep_beds)
+  wipe_db_path(
+    FLAGS.filename, FLAGS.keep_beds, FLAGS.reset_admin, FLAGS.admin_email,
+    os.environ.get("ICUBAM_ADMIN_PASS", FLAGS.admin_pass)
+  )
 
 
 if __name__ == "__main__":

--- a/scripts/wipe_sensitive_info_db.py
+++ b/scripts/wipe_sensitive_info_db.py
@@ -18,7 +18,10 @@ flags.DEFINE_boolean(
 )
 flags.DEFINE_boolean("reset_admin", False, "Reset admin information")
 flags.DEFINE_string("admin_email", None, "Admin email (if resetting admins)")
-flags.DEFINE_string("admin_pass", None, "Admin password (if resetting admins)")
+flags.DEFINE_string(
+  "admin_pass", None,
+  "Admin password (if resetting admins). Set the env variable ICUBAM_ADMIN_PASS to override"
+)
 flags.DEFINE_string("filename", None, 'DB file name.')
 flags.mark_flag_as_required('filename')
 FLAGS = flags.FLAGS


### PR DESCRIPTION
This should have been two separate PRs but, oh well...

Rewrite the wipe script using SQLAlchemy to gain some future-proofing + add the option to reset admin username/password (may be useful on staging server)