### PR TITLE
Fix missing config copy in Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,9 +2,9 @@
 .github
 .gitignore
 data
-deploy_configs
-deploy_configs.tgz
 icubam.egg-info
 docker/configs/certbot
 docker/scripts
 docker/resources
+test.db
+icubam.db

--- a/.dockerignore
+++ b/.dockerignore
@@ -6,5 +6,5 @@ icubam.egg-info
 docker/configs/certbot
 docker/scripts
 docker/resources
-test.db
-icubam.db
+**/*.db
+

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,7 +36,7 @@ COPY scripts scripts
 RUN  mkdir resources
 
 # copy specific files on root folder
-COPY LICENSE pyproject.toml README.md requirements.txt requirements-test.txt setup.py ./
+COPY LICENSE pyproject.toml README.md requirements.txt requirements-test.txt setup.py conftest.py ./
 
 # pip/setup tools requires version inside .git
 COPY .git ./.git


### PR DESCRIPTION
Solves #351 

Fix error in Action for docker image creation due to missing conftest.py.

The conftest.py file has been added in Dockerfile, which uses explicit copy of specific files and folders, and not a blanket copy of everything in the build folder except those in .dockerignore. 
While this prevents building a docker image with extra/unwanted files added in the local build folder (on test/dev machines) it also has the potential to create bugs if the Dockerfile has not been properly updated.

@rth @marccarre any recommendation for this ? (do blanket copy anyway as (1) on CICD, no risks or unwanted files in the image and (2) the images built on dev machines are just local anyway).
