### PR TITLE
Plot generation script

### DIFF
--- a/doc/cli.md
+++ b/doc/cli.md
@@ -1,0 +1,37 @@
+# Command Line Interface (CLI)
+
+## icubam.predicu
+<!-- The following help needs to be manually regenerated
+  with <script> help as long as we keep a documentaton in markdown
+-->
+
+**icubam.predicu export**
+```
+$ python -m icubam.predicu export --help
+Usage: __main__.py export [OPTIONS]
+
+Options:
+  -o, --output-dir TEXT
+  --api-key TEXT
+  --spread-cum-jump-correction BOOLEAN
+  --icubam-host TEXT
+  --max-date TEXT                 max date of the exported data (e.g.
+                                  2020-04-05)
+
+  --help                          Show this message and exit.
+```
+
+**icubam.predicu make_dashboard_plots**
+```
+$ python -m icubam.predicu make_dashboard_plots --help
+Usage: __main__.py make_dashboard_plots [OPTIONS]
+
+  Make dasboard plots
+
+Options:
+  -o, --config TEXT      ICUBAM config file.  [required]
+  -o, --output-dir TEXT  Output directory where to store plots. If not
+                         provided config.backoffice.extra_plots_dir is used.
+
+  --help                 Show this message and exit.
+```

--- a/icubam/predicu/__main__.py
+++ b/icubam/predicu/__main__.py
@@ -29,6 +29,14 @@ def cli():
   help="max date of the exported data (e.g. 2020-04-05)",
   type=str
 )
+def export_data_cli(
+  output_dir, api_key, spread_cum_jump_correction, icubam_host, max_date
+):
+  export_data(
+    output_dir, api_key, spread_cum_jump_correction, icubam_host, max_date
+  )
+
+
 def export_data(
   output_dir, api_key, spread_cum_jump_correction, icubam_host, max_date
 ):

--- a/icubam/predicu/__main__.py
+++ b/icubam/predicu/__main__.py
@@ -1,16 +1,16 @@
-from pathlib import Path
+import asyncio
 import datetime
 import logging
 import os
 import sys
+from pathlib import Path
 
-import asyncio
 import click
 
 from icubam.config import Config
 from icubam.db.store import create_store_factory_for_sqlite_db
-from icubam.predicu.data import load_bedcounts
 from icubam.predicu.analytics_server import AnalyticsCallback
+from icubam.predicu.data import load_bedcounts
 
 
 @click.group()
@@ -52,17 +52,28 @@ def export_data(
   logging.info("export DONE.")
 
 
-@cli.command(name="make_dashboard_plots")
+@cli.command(name="make_dashboard_plots", help="Make dasboard plots ")
 @click.option(
   "--config", "-o", type=str, required=True, help="ICUBAM config file."
 )
-@click.option("--output-dir", "-o", default="/tmp", type=str)
+@click.option(
+  "--output-dir",
+  "-o",
+  type=str,
+  help=(
+    "Output directory where to store plots. If not provided "
+    "config.backoffice.extra_plots_dir is used."
+  )
+)
 def make_dasboard_plots(config, output_dir):
   config = Config(config)
   # Make sure DB path exists, to avoid creating an empty one
   if not Path(config.db.sqlite_path).exists():
     click.echo(f"Could not find DB at {config.db.sqlite_path}!", err=True)
     sys.exit(1)
+
+  if output_dir is None:
+    output_dir = config.backoffice.extra_plots_dir
 
   output_dir = Path(output_dir)
   if not output_dir.exists():

--- a/icubam/predicu/analytics_server.py
+++ b/icubam/predicu/analytics_server.py
@@ -9,8 +9,8 @@ from icubam.predicu.plot import generate_plots
 
 
 class AnalyticsCallback:
-  def __init__(self, config: Config, db_factory):
-    self.config = config
+  def __init__(self, output_dir, db_factory):
+    self.output_dir = output_dir
     self.db_factory = db_factory
 
   async def generate_plots(self):
@@ -22,7 +22,7 @@ class AnalyticsCallback:
     generate_plots(
       plots=["flux_dept_lits_dept_visu_4panels"],
       cached_data=cached_data,
-      output_dir=self.config.backoffice.extra_plots_dir
+      output_dir=self.output_dir
     )
 
 
@@ -53,5 +53,5 @@ def register_analytics_callback(config: Config, db_factory, ioloop) -> None:
       f"Registering periodic callback: generate_predicu_plots "
       f"/{repeat_every/1000}s"
     )
-    callback = AnalyticsCallback(config, db_factory)
+    callback = AnalyticsCallback(config.backoffice.extra_plots_dir, db_factory)
     ioloop.PeriodicCallback(callback.generate_plots, repeat_every).start()

--- a/icubam/predicu/analytics_server.py
+++ b/icubam/predicu/analytics_server.py
@@ -24,6 +24,7 @@ class AnalyticsCallback:
       cached_data=cached_data,
       output_dir=self.output_dir
     )
+    logging.info('[periodic callback] Finished plots generation with predicu')
 
 
 def register_analytics_callback(config: Config, db_factory, ioloop) -> None:

--- a/icubam/predicu/tests/test_export_data.py
+++ b/icubam/predicu/tests/test_export_data.py
@@ -1,5 +1,3 @@
-import collections
-
 import icubam.predicu.data as icubam_data
 from icubam.predicu.test_utils import load_test_data
 
@@ -18,17 +16,11 @@ def test_export_data(tmpdir, monkeypatch):
     make_monkeypatch_load_bedcounts(cached_data['bedcounts'])
   )
   import icubam.predicu.__main__
-  TestArgs = collections.namedtuple(
-    'TestArgs', [
-      'output_dir', 'api_key', 'max_date', 'icubam_host',
-      'spread_cum_jump_correction'
-    ]
-  )
-  test_args = TestArgs(
+  test_args = dict(
     output_dir=str(tmpdir),
     api_key='test_api_key',
     max_date=None,
     icubam_host='localhost',
     spread_cum_jump_correction=False,
   )
-  icubam.predicu.__main__.export_data(test_args)
+  icubam.predicu.__main__.export_data(**test_args)


### PR DESCRIPTION
Adds a script to manually generate plots for the dashboard https://github.com/icubam/icubam/issues/284 instead of the callback https://github.com/icubam/icubam/pull/222

There is some redundancy with `icubam.predicu.plot.__main__` but I thin we should move that one, one level up and expose it as `python -m icubam.predicu plot`, otherwise if each module has a script it's a bit hard to discover.   