### PR TITLE
SImple script to automate demo deployment, documentation update

### DIFF
--- a/doc/docker.md
+++ b/doc/docker.md
@@ -95,9 +95,7 @@ Two kinds of environment variables must be set
 **Docker's environement variables**
 
 - ICUBAM_COMPOSE_CONTEXT: root folder for the build context
-- ICUBAM_CONFIG_PATH: path/filename for the app's configuration file
-- ICUBAM_PROD_DB_PATH: path/filename for the production database
-- ICUBAM_TEST_DB_PATH: path/filename for the test database
+- ICUBAM_RESOURCES_PATH: path/name of the resources folder to mount in the container (e.g., `./resources`). This folder contains, among other things, the app's configuration file and the database).
 - ICUBAM_CERTBOT_PATH: location for the CertBot configuration and result files
 - ICUBAM_NGINX_PATH: location for the Nginx configuration files
 - IMAGE_NAME: name of the Docker image to use
@@ -110,11 +108,14 @@ Files/folders are mounted (bind) in the containers (nginx/certbot) defined in th
 
 The containers expect the following variables to be set in order to launch
 
+- ICUBAM_CONFIG_FILE: filename for the app's configuration file (e.g., `icubam.toml`)
 - SECRET_COOKIE
 - JWT_SECRET
 - GOOGLE_API_KEY
 - TW_KEY
 - TW_API
+- TW_API
+- DB_SALT
 
 These environment variables are not set in the Docker image, but must be set when starting the 
 docker/docker-compose command.  Also check the [install.md](./install.md) documentation for more details.

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -92,35 +92,26 @@ Two kinds of environment variables must be set
 - env. variables used by the app's services
 - env. variables used by docker/docker-compose when building/launching the application 
 
+**Application's environement variables**
+
+Check [Installation instructions](install.md#Configuration) for the required variables
+  
 **Docker's environement variables**
 
 - ICUBAM_COMPOSE_CONTEXT: root folder for the build context
 - ICUBAM_RESOURCES_PATH: path/name of the resources folder to mount in the container (e.g., `./resources`). This folder contains, among other things, the app's configuration file and the database).
+- ICUBAM_CONFIG_FILE: filename for the app's configuration file (e.g., `icubam.toml`) expected in the `./resources` folder
 - ICUBAM_CERTBOT_PATH: location for the CertBot configuration and result files
 - ICUBAM_NGINX_PATH: location for the Nginx configuration files
 - IMAGE_NAME: name of the Docker image to use
 - IMAGE_TAG: tag of the Docker image to use
 - LOGS_DIR: folder where log files (e.g., './logs')
 
-Files/folders are mounted (bind) in the containers (nginx/certbot) defined in the `docker-compose-proxy.yml`file.
-
-**Application's environement variables**
-
-The containers expect the following variables to be set in order to launch
-
-- ICUBAM_CONFIG_FILE: filename for the app's configuration file (e.g., `icubam.toml`)
-- SECRET_COOKIE
-- JWT_SECRET
-- GOOGLE_API_KEY
-- TW_KEY
-- TW_API
-- TW_API
-- DB_SALT
-
-These environment variables are not set in the Docker image, but must be set when starting the 
-docker/docker-compose command.  Also check the [install.md](./install.md) documentation for more details.
+Folders (i.e., resources, nginx, certbot) are mounted (bind) in the containers defined in the docker-compose yml files.
 
 **Setting up environement variables**
+
+Environment variables are not part of the Docker image, but are provided to the starting containers thru the docker/docker-compose commands.
 
 There are multiple ways for setting up these variables.
 - have a .env file at the root of the project
@@ -144,21 +135,20 @@ set -a
 
 **Example .env file**
 
-These work straight out of the box with the docker-compose scripts provided if you run them from the root folder
+For the application's environment variables, check the repository for an up-to-date list.
+Below are the Docker specific environement variables with default values.
+
 ```properties
 # Application's environement variables
-SECRET_COOKIE=_a_random_string_
-JWT_SECRET=_jwt_secret_string_
-GOOGLE_API_KEY=_google_api_key_string_
-TW_KEY=_twilio_key_string_
-TW_API=_twilio_api_string_
-DB_SALT=_another_random_string_
 
 # Docker's environement variables
 ICUBAM_COMPOSE_CONTEXT=.
 ICUBAM_RESOURCES_PATH=./resources
+ICUBAM_CONFIG_FILE=config.toml
 ICUBAM_CERTBOT_PATH=../docker/configs/certbot
 ICUBAM_NGINX_PATH=../docker/configs/nginx
+IMAGE_NAME=icubam
+IMAGE_TAG=latest
 LOGS_DIR=../logs
 ```
 

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -135,7 +135,7 @@ set -a
 
 **Example .env file**
 
-For the application's environment variables, check the repository for an up-to-date list.
+For the application's environment variables, see the identically named section above.
 Below are the Docker specific environement variables with default values.
 
 ```properties

--- a/doc/install.md
+++ b/doc/install.md
@@ -35,7 +35,7 @@ N.B.: You can name and move this file as you want but you will have to add
 ### Pre-populate DB with test data
 
 Create a fake database in order to be able to play with it:
-`python scripts/populate_db_fake.py --config=resources/config.toml --mode=dev`
+`python scripts/populate_db_fake.py --config=resources/config.toml`
 
 The database will be named `test.db`, cf. `resources/config.toml`.
 
@@ -60,7 +60,7 @@ To get all identifiers:
 ### Main server
 
 Start the main server locally:
-`python scripts/run_server.py --config=resources/config.toml --mode=dev`
+`python scripts/run_server.py --config=resources/config.toml`
 
 Will produce the following logs:
 ```

--- a/docker/build_fake_dbs.sh
+++ b/docker/build_fake_dbs.sh
@@ -2,4 +2,4 @@
 
 # launch the DB creation
 echo "Build test db"
-PYTHONPATH=. python scripts/populate_db_fake.py --config="/home/icubam/resources/${ICUBAM_CONFIG_FILE:-icubam.toml}"
+python3 scripts/populate_db_fake.py --config="/home/icubam/resources/${ICUBAM_CONFIG_FILE:-icubam.toml}"

--- a/docker/build_fake_dbs.sh
+++ b/docker/build_fake_dbs.sh
@@ -1,14 +1,5 @@
 #!/bin/bash
 
-# conda init, activate environment
-# and add current module (icubam) in edit/develop mode
-conda init bash
-conda activate icubam
-
-# launch the server
-pwd
-ls -a
+# launch the DB creation
 echo "Build test db"
-PYTHONPATH=. python scripts/populate_db_fake.py --config=resources/config.toml
-
-cp ./test.db ./db/
+PYTHONPATH=. python scripts/populate_db_fake.py --config="/home/icubam/resources/${ICUBAM_CONFIG_FILE:-icubam.toml}"

--- a/docker/docker-compose-init-db.yml
+++ b/docker/docker-compose-init-db.yml
@@ -4,13 +4,14 @@ services:
   # ICUBAM service
   db-builder:
     build:
-      context: "${ICUBAM_COMPOSE_CONTEXT:-..}"
+      context: "${ICUBAM_COMPOSE_CONTEXT:-.}"
       dockerfile: ./docker/Dockerfile
     image: "${IMAGE_NAME:-icubam}:${IMAGE_TAG:-latest}"
     container_name: db-builder
-    command: "./build_fake_dbs.sh"
+    command: "./docker/build_fake_dbs.sh"
     tty: true
     environment:
+      ICUBAM_CONFIG_FILE : "${ICUBAM_CONFIG_FILE:-icubam.toml}"
       SECRET_COOKIE : "$SECRET_COOKIE"
       JWT_SECRET : "$JWT_SECRET"
       GOOGLE_API_KEY : "$GOOGLE_API_KEY"
@@ -22,9 +23,6 @@ services:
       - type: bind
         source: "${ICUBAM_RESOURCES_PATH:-./resources}"
         target: /home/icubam/resources
-      - type: bind
-        source: "${ICUBAM_COMPOSE_CONTEXT:-.}"
-        target: /home/icubam/db
     networks:
       - icubam-network
 

--- a/docker/scripts/install_test_deployment.sh
+++ b/docker/scripts/install_test_deployment.sh
@@ -20,20 +20,23 @@ fi
 # envvar file
 if [ -f "${ENVFILE}" ]; then
   echo -e "\n${ENVFILE} exist, load envvars"i
+  # shellcheck source=.env
   source ${ENVFILE}
 else
 	echo -e "\n###\nCreate default envvar file ${ENVFILE}"
 	touch ${ENVFILE}
-	echo "IMAGE_NAME=icubam" >> ${ENVFILE}
-	echo "IMAGE_TAG=latest" >> ${ENVFILE}
-	echo "ICUBAM_COMPOSE_CONTEXT=." >> ${ENVFILE}
-	echo "ICUBAM_CONFIG_FILE=${CONFFILE}" >> ${ENVFILE}
-	echo "SECRET_COOKIE=_random_string_" >> ${ENVFILE}
-	echo "JWT_SECRET=_random_string_" >> ${ENVFILE}
-	echo "GOOGLE_API_KEY=_random_string_" >> ${ENVFILE}
-	echo "TW_KEY=_random_string_" >> ${ENVFILE}
-	echo "TW_API=_random_string_" >> ${ENVFILE}
-	echo "DB_SALT=_random_string_" >> ${ENVFILE}
+	{
+    echo "IMAGE_NAME=icubam"
+    echo "IMAGE_TAG=latest"
+    echo "ICUBAM_COMPOSE_CONTEXT=."
+    echo "ICUBAM_CONFIG_FILE=${CONFFILE}"
+    echo "SECRET_COOKIE=_random_string_"
+    echo "JWT_SECRET=_random_string_"
+    echo "GOOGLE_API_KEY=_random_string_"
+    echo "TW_KEY=_random_string_"
+    echo "TW_API=_random_string_"
+    echo "DB_SALT=_random_string_"
+  } >> ${ENVFILE}
 
 	echo "Now update the ${ENVFILE} file with the proper values and launch the script again"
 	exit 0
@@ -41,7 +44,7 @@ fi
 
 # Retrieve Docker image
 echo -e "\n###\nRetrieve ICUBAM Docker image ${IMAGE_NAME}:${IMAGE_TAG}"
-docker pull ${IMAGE_NAME}:${IMAGE_TAG}
+docker pull "${IMAGE_NAME}":"${IMAGE_TAG}"
 
 # Retrieve docker-compose files - assume there is an external reverse-proxy facility for the deployment
 echo -e "\n###\nDownload compose files"

--- a/docker/scripts/install_test_deployment.sh
+++ b/docker/scripts/install_test_deployment.sh
@@ -20,7 +20,8 @@ fi
 # envvar file
 if [ -f "${ENVFILE}" ]; then
   echo -e "\n${ENVFILE} exist, load envvars"i
-  # shellcheck source=.env
+  # .env generated at runtime, cannot check with shellcheck
+  # shellcheck disable=SC1091
   source ${ENVFILE}
 else
 	echo -e "\n###\nCreate default envvar file ${ENVFILE}"

--- a/docker/scripts/install_test_deployment.sh
+++ b/docker/scripts/install_test_deployment.sh
@@ -20,8 +20,7 @@ fi
 # envvar file
 if [ -f "${ENVFILE}" ]; then
   echo -e "\n${ENVFILE} exist, load envvars"i
-  # .env generated at runtime, cannot check with shellcheck
-  # shellcheck disable=SC1091
+  # shellcheck disable=SC1090
   source ${ENVFILE}
 else
 	echo -e "\n###\nCreate default envvar file ${ENVFILE}"

--- a/docker/scripts/install_test_deployment.sh
+++ b/docker/scripts/install_test_deployment.sh
@@ -7,12 +7,22 @@
 ENVFILE=".env"
 CONFFILE="config.toml"
 
+# check that docker is indeed installed
+if ! [ -x "$(command -v docker)" ]; then
+  echo 'Error: docker is not installed.' >&2
+  exit 1
+fi
+if ! [ -x "$(command -v docker-compose)" ]; then
+  echo 'Error: docker-compose is not installed.' >&2
+  exit 1
+fi
+
 # envvar file
 if [ -f "${ENVFILE}" ]; then
   echo -e "\n${ENVFILE} exist, load envvars"i
   source ${ENVFILE}
 else
-	echo -e "\nCreate default envvar file ${ENVFILE}"
+	echo -e "\n###\nCreate default envvar file ${ENVFILE}"
 	touch ${ENVFILE}
 	echo "IMAGE_NAME=icubam" >> ${ENVFILE}
 	echo "IMAGE_TAG=latest" >> ${ENVFILE}
@@ -30,11 +40,11 @@ else
 fi
 
 # Retrieve Docker image
-echo -e "\nRetrieve ICUBAM Docker image ${IMAGE_NAME}:${IMAGE_TAG}"
+echo -e "\n###\nRetrieve ICUBAM Docker image ${IMAGE_NAME}:${IMAGE_TAG}"
 docker pull ${IMAGE_NAME}:${IMAGE_TAG}
 
 # Retrieve docker-compose files - assume there is an external reverse-proxy facility for the deployment
-echo -e "\nDownload compose files"
+echo -e "\n###\nDownload compose files"
 rm -f docker-compose-core.yml docker-compose-init-db.yml
 wget https://raw.githubusercontent.com/icubam/icubam/master/docker/docker-compose-init-db.yml
 wget https://raw.githubusercontent.com/icubam/icubam/master/docker/docker-compose-core.yml
@@ -46,7 +56,7 @@ mkdir -p resources
 if [ -f "resources/${CONFFILE}" ]; then
     echo -e "\nresources/${CONFFILE} exist, use it"i
 else
-	echo -e "\nGet default config file for containers"
+	echo -e "\n###\nGet default config file for containers"
 	wget https://raw.githubusercontent.com/icubam/icubam/master/resources/config.toml
 	mv config.toml resources
 
@@ -55,12 +65,12 @@ else
 fi
 
 # Initialize the default test database
-echo -e "\nInitialize fake database"
+echo -e "\n###\nInitialize fake database"
 docker-compose -f docker-compose-init-db.yml --project-directory . up
 docker-compose -f docker-compose-init-db.yml --project-directory . down
 
 # launch the icubam services
-echo -e "\nLaunch app containers"
+echo -e "\n###\nLaunch app containers"
 docker-compose -f docker-compose-core.yml  --project-directory . up -d
 
 

--- a/docker/scripts/install_test_deployment.sh
+++ b/docker/scripts/install_test_deployment.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# script to install and deploy the ICUBAM app containers locally with a test database
+#
+
+# local definitions. The ".env" is automatically loaded by compose.
+ENVFILE=".env"
+CONFFILE="config.toml"
+
+# envvar file
+if [ -f "${ENVFILE}" ]; then
+  echo -e "\n${ENVFILE} exist, load envvars"i
+  source ${ENVFILE}
+else
+	echo -e "\nCreate default envvar file ${ENVFILE}"
+	touch ${ENVFILE}
+	echo "IMAGE_NAME=icubam" >> ${ENVFILE}
+	echo "IMAGE_TAG=latest" >> ${ENVFILE}
+	echo "ICUBAM_COMPOSE_CONTEXT=." >> ${ENVFILE}
+	echo "ICUBAM_CONFIG_FILE=${CONFFILE}" >> ${ENVFILE}
+	echo "SECRET_COOKIE=_random_string_" >> ${ENVFILE}
+	echo "JWT_SECRET=_random_string_" >> ${ENVFILE}
+	echo "GOOGLE_API_KEY=_random_string_" >> ${ENVFILE}
+	echo "TW_KEY=_random_string_" >> ${ENVFILE}
+	echo "TW_API=_random_string_" >> ${ENVFILE}
+	echo "DB_SALT=_random_string_" >> ${ENVFILE}
+
+	echo "Now update the ${ENVFILE} file with the proper values and launch the script again"
+	exit 0
+fi
+
+# Retrieve Docker image
+echo -e "\nRetrieve ICUBAM Docker image ${IMAGE_NAME}:${IMAGE_TAG}"
+docker pull ${IMAGE_NAME}:${IMAGE_TAG}
+
+# Retrieve docker-compose files - assume there is an external reverse-proxy facility for the deployment
+echo -e "\nDownload compose files"
+rm -f docker-compose-core.yml docker-compose-init-db.yml
+wget https://raw.githubusercontent.com/icubam/icubam/master/docker/docker-compose-init-db.yml
+wget https://raw.githubusercontent.com/icubam/icubam/master/docker/docker-compose-core.yml
+
+# Create default folder for resources (configuration file and databases)
+mkdir -p resources
+
+# retrieve the default configuration file and move to the resources folder
+if [ -f "resources/${CONFFILE}" ]; then
+    echo -e "\nresources/${CONFFILE} exist, use it"i
+else
+	echo -e "\nGet default config file for containers"
+	wget https://raw.githubusercontent.com/icubam/icubam/master/resources/config.toml
+	mv config.toml resources
+
+	echo "Now update the ${CONFFILE} file with the proper values and launch the script again"
+  exit 0
+fi
+
+# Initialize the default test database
+echo -e "\nInitialize fake database"
+docker-compose -f docker-compose-init-db.yml --project-directory . up
+docker-compose -f docker-compose-init-db.yml --project-directory . down
+
+# launch the icubam services
+echo -e "\nLaunch app containers"
+docker-compose -f docker-compose-core.yml  --project-directory . up -d
+
+


### PR DESCRIPTION
Closes #381

**Why?**

Installing a basic instance of the platform for demonstration involves a number of step which are easy to get wrong. A simple, automated procedure is required in order to have people quickly play with the platform with a default database. 

**What?**

This PR adds a simple script that
-  creates the envvar file with default values (its content must be updated by the user and the install script launched again)
- download the relevant config and compose files from the github repository
- create resources folder, and generate the fake databae in it
- launches the app's containers (www, sms, back-office)

The app is then available using the url to access directly the back-office (http://localhost:8890/bo/) and the map (http://localhost:8888/) 

The script assumes docker and docker-compose are installed.

Testing notes
- The script can be downloaded using `wget https://raw.githubusercontent.com/icubam/icubam/pierreg_install_auto/docker/scripts/install_test_deployment.sh`
- while the script relies on compose/config files on the `master` branch, until this branch is merged, the script should be updated to fetch the files from the `pierreg_install_auto` branch (3 instances to replace)
- Since the Docker image cannot be downloaded from Github without credentials, a temporary repository has been setup on Inria's Gitlab. The following tags should be set in the envvar file (after the first execution of the script)
```
IMAGE_NAME=registry.gitlab.inria.fr/praverdy/icubam_docker
IMAGE_TAG=latest
```
- while the script exits a second time to let the user edit the `resources/config.toml` file if required, for testing it can just be re-launched 
