### PR TITLE
Add Terraform template to create VM under GCP

### DIFF
--- a/.github/workflows/terraform-check.yml
+++ b/.github/workflows/terraform-check.yml
@@ -1,0 +1,31 @@
+name: Lint .tf files
+
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the master branch
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  terraform-check:
+    env:
+      VERSION: "0.12.24"
+      SHA256_HASH: "602d2529aafdaa0f605c06adb7c72cfb585d8aa19b3f4d8d189b42589e27bf11"
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install Terraform
+      run: |
+        curl -fsSLO "https://releases.hashicorp.com/terraform/${VERSION}/terraform_${VERSION}_linux_amd64.zip" && \
+          echo "${SHA256_HASH}  terraform_${VERSION}_linux_amd64.zip" | sha256sum -c && \
+          unzip "terraform_${VERSION}_linux_amd64.zip" && \
+          sudo mv terraform /usr/local/bin && \
+          rm -f "terraform_${VERSION}_linux_amd64.zip" && \
+          terraform version
+    - name: Run terraform fmt -check
+      run: |
+        terraform fmt -check -recursive || echo "Incorrectly formatted Terraform files. Please run: terraform fmt"

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,8 @@ settings.json
 
 # mypy
 .mypy_cache/
+
+# Terraform files:
+.terraform/
+terraform.tfstate
+terraform.tfstate.backup

--- a/deploy/gcp/gce/README.md
+++ b/deploy/gcp/gce/README.md
@@ -41,6 +41,14 @@ export GCP_PROJECT_ID="icubam-272015"
 export GCP_SA_NAME="$(whoami)"
 ```
 
+Optionally, to avoid having Terraform prompt you on every command, you can have:
+
+```console
+export TF_VAR_gcp_project_id="${GCP_PROJECT_ID}"
+export TF_VAR_project_name="$(whoami)-test"
+export TF_VAR_ssh_username="$(whoami)"
+```
+
 Otherwise, please run:
 
 ```console

--- a/deploy/gcp/gce/README.md
+++ b/deploy/gcp/gce/README.md
@@ -1,0 +1,91 @@
+# Google Cloud Engine
+
+[Google Cloud Engine][gcp-gce] is a service offering VMs in Google's cloud.
+In that sense, running ICUBAM on GCE is not particularly different from any
+other VM.
+
+This example shows how to deploy ICUBAM on GCE using Terraform, which brings the
+benefits of Infrastructure as Code (IaC), such as:
+
+- a human (and machine) readable description of your infrastructure,
+- the ability to reliably reproduce your setup.
+
+## Setup
+
+### Pre-requisites
+
+1. Create or select a project from the [GCP's projects page][gcp-projects].
+2. Download & install [GCP's SDK / `gcloud`][gcp-sdk]. This will be used for
+   imperative, one-time operations.
+3. Download & install [Terraform][tf-dl]. This will be used to manage your
+   infrastructure in a declarative way.
+
+### Initialisation
+
+In order to manage your infrastructure in a declarative way via Terraform, we
+need to:
+
+- create a service account,
+- configure this service account with a minimum set of permissions,
+- create a key so that it can securely access GCP.
+
+If you have all this already, please ensure the following environment variable
+are:
+
+- set (replace the values with appropriate ones, where relevant),
+- exported (you can use [`direnv`][direnv] for that purpose).
+
+```console
+export GOOGLE_CLOUD_KEYFILE_JSON="${HOME}/.gcp/icubam.json"
+export GCP_PROJECT_ID="icubam-272015"
+export GCP_SA_NAME="$(whoami)"
+```
+
+Otherwise, please run:
+
+```console
+./init.sh
+```
+
+### Terraforming
+
+#### Create / Update
+
+To create or update your infrastructure, run:
+
+```console
+terraform apply
+```
+
+#### Delete
+
+To delete your infrastructure, run:
+
+```console
+terraform destroy
+```
+
+### Notes
+
+Various [permissions][gcp-permissions] are required to create, access, update or
+delete VMs and network components in GCP, e.g.:
+
+- `compute.networks.create`
+- `compute.images.get`
+- `compute.instances.create`
+- `compute.disks.create`
+- `compute.instances.setMetadata`
+- and many others.
+
+The `compute.admin` role seem to include most of these permissions, while also
+not being too permissive and therefore following the
+"_Least Privilege Principle_" and is therefore what is being used by `init.sh`.
+This can be overriden by setting `GCP_ROLE` to any other preferred value.
+
+[direnv]: https://direnv.net/
+[gcp-gce]: https://cloud.google.com/compute
+[gcp-permissions]: https://cloud.google.com/iam/docs/permissions-reference
+[gcp-projects]: https://console.cloud.google.com/project
+[gcp-sa]: https://console.cloud.google.com/iam-admin/serviceaccounts
+[gcp-sdk]: https://cloud.google.com/sdk/install
+[tf-dl]: https://www.terraform.io/downloads.html

--- a/deploy/gcp/gce/gce.tf
+++ b/deploy/gcp/gce/gce.tf
@@ -1,0 +1,32 @@
+provider "google" {
+  project = var.gcp_project_id
+  region  = var.gcp_region
+  zone    = var.gcp_zone
+  version = "~> 3.18"
+}
+
+resource "google_compute_address" "static" {
+  name = "${var.project_name}-ipv4-address"
+}
+
+resource "google_compute_instance" "vm_instance" {
+  name         = "${var.project_name}-instance"
+  machine_type = var.gcp_machine_type
+
+  boot_disk {
+    initialize_params {
+      image = var.gcp_os_image
+    }
+  }
+
+  network_interface {
+    network = "default"
+    access_config {
+      nat_ip = google_compute_address.static.address
+    }
+  }
+
+  metadata = {
+    ssh-keys = "${var.ssh_username}:${file(var.ssh_public_key_path)}"
+  }
+}

--- a/deploy/gcp/gce/init.sh
+++ b/deploy/gcp/gce/init.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+
+# Description:
+#   Performs the one-time configuration/bootstrapping required to manage
+#   a deployment to GCE through Terraform.
+#
+# Dependencies:
+#   - gcloud (https://cloud.google.com/sdk/install)
+#   - terraform (https://www.terraform.io/downloads.html)
+#
+# Optional input environment variables:
+#   - GCP_PROJECT_ID: GCP project's unique ID.
+#   - GCP_SA_NAME: GCP service account name.
+#   - GOOGLE_CLOUD_KEYFILE_JSON: path to GCP service account JSON keyfile, used by Terraform.
+
+set -e
+
+
+GCP_PROJECT_ID="${GCP_PROJECT_ID:-}"
+GCP_SA_NAME="${GCP_SA_NAME:-}"
+
+GCP_ROLE="${GCP_ROLE:-compute.admin}"
+GOOGLE_CLOUD_KEYFILE_JSON="${GOOGLE_CLOUD_KEYFILE_JSON:-"${HOME}/.gcp/icubam.json"}"
+
+
+function check_cmd_exists() {
+  local cmd="${1}"
+  command -v "${cmd}" >/dev/null 2>&1 || {
+    echo >&2 "ERROR: ${cmd} is required but could not be found in \$PATH."
+    return 1
+  }
+}
+
+function check_envvar_exists() {
+  local envvar="${1}"
+  [ -n "${!envvar}" ] || {
+    echo >&2 "WARNING: ${envvar} is not set."
+  }
+}
+
+function check_dependencies() {
+  local status=0
+  for cmd in gcloud terraform ; do
+    if ! check_cmd_exists "${cmd}" ; then
+      status=1
+    fi
+  done
+  for envvar in GCP_PROJECT_ID GCP_SA_NAME GOOGLE_CLOUD_KEYFILE_JSON ; do
+    check_envvar_exists "${envvar}"
+  done
+  return "${status}"
+}
+
+function print_envvar_instructions() {
+  local envvar="${1}"
+  echo >&2 "Going forward, please ensure the following environment variable is exported:"
+  echo >&2 "\$ export ${envvar}=\"${!envvar}\""
+}
+
+function choose_gcp_project() {
+  gcloud projects list
+  read -r -p "Enter project ID: " GCP_PROJECT_ID
+  export GCP_PROJECT_ID
+  print_envvar_instructions "GCP_PROJECT_ID"
+}
+
+function create_gcp_service_account() {
+  read -r -p "Enter service account username: " GCP_SA_NAME
+  export GCP_SA_NAME
+  print_envvar_instructions "GCP_SA_NAME"
+
+  # Create a new service account, with least privilege, to use with Terraform:
+  gcloud iam service-accounts create "${GCP_SA_NAME}" \
+    --description "${GCP_SA_NAME}'s service account to automatically deploy to GCP via Terraform" \
+    --display-name "${GCP_SA_NAME}"
+
+  # Grant required permissions to the created service account:
+  gcloud projects add-iam-policy-binding "${GCP_PROJECT_ID}" \
+    --member "serviceAccount:${GCP_SA_NAME}@${GCP_PROJECT_ID}.iam.gserviceaccount.com" \
+    --role "roles/${GCP_ROLE}"
+}
+
+function create_gcp_key_file() {
+  # Create a JSON key on your machine, to be provided to Terraform later on:
+  mkdir -p "$(dirname "${GOOGLE_CLOUD_KEYFILE_JSON}")"
+  gcloud iam service-accounts keys create "${GOOGLE_CLOUD_KEYFILE_JSON}" \
+    --iam-account "${GCP_SA_NAME}@${GCP_PROJECT_ID}.iam.gserviceaccount.com"
+  export GOOGLE_CLOUD_KEYFILE_JSON
+  print_envvar_instructions "GOOGLE_CLOUD_KEYFILE_JSON"
+}
+
+function init_gcp() {
+  gcloud version
+  gcloud auth login
+  [ -z "${GCP_PROJECT_ID}" ] && choose_gcp_project
+  gcloud config set project "${GCP_PROJECT_ID}"
+  [ -z "${GCP_SA_NAME}" ] && create_gcp_service_account
+  [ ! -f "${GOOGLE_CLOUD_KEYFILE_JSON}" ] && create_gcp_key_file
+}
+
+function init_terraform() {
+  terraform version
+  terraform init
+  terraform plan
+}
+
+function main() {
+  check_dependencies
+  init_gcp
+  init_terraform
+}
+
+main

--- a/deploy/gcp/gce/outputs.tf
+++ b/deploy/gcp/gce/outputs.tf
@@ -1,0 +1,7 @@
+output "public_ips" {
+  value = ["${google_compute_instance.vm_instance.*.network_interface.0.access_config.0.nat_ip}"]
+}
+
+output "private_ips" {
+  value = ["${google_compute_instance.vm_instance.*.network_interface.0.network_ip}"]
+}

--- a/deploy/gcp/gce/variables.tf
+++ b/deploy/gcp/gce/variables.tf
@@ -1,0 +1,55 @@
+variable "gcp_project_id" {
+  description = "Google Cloud Platform selected project's ID"
+}
+
+variable "ssh_username" {
+  description = "User to configure SSH access for"
+}
+
+variable "ssh_public_key_path" {
+  description = "Path to file containing public key"
+  default     = "~/.ssh/id_rsa.pub"
+}
+
+variable "ssh_private_key_path" {
+  description = "Path to file containing private key"
+  default     = "~/.ssh/id_rsa"
+}
+
+variable "project_name" {
+  description = "Project name, used to name VMs and other resources"
+  default     = "icubam"
+}
+
+variable "gcp_region" {
+  # See also:
+  # - https://cloud.google.com/compute/docs/regions-zones
+  # - $ gcloud compute regions list
+  description = "Google Cloud Platform's selected region"
+  default     = "europe-west1"
+}
+
+variable "gcp_zone" {
+  # See also:
+  # - https://cloud.google.com/compute/docs/regions-zones
+  # - $ gcloud compute zones list
+  description = "Google Cloud Platform's selected zone"
+  default     = "europe-west1-b"
+}
+
+variable "gcp_machine_type" {
+  # See also:
+  # - https://cloud.google.com/compute/docs/machine-types
+  # - $ gcloud compute machine-types list
+  description = "Google Cloud Platform's selected machine type"
+  default     = "f1-micro"
+}
+
+variable "gcp_os_image" {
+  # See also:
+  # - https://cloud.google.com/compute/docs/images
+  # - $ gcloud compute images list
+  description = "Google Cloud Platform OS"
+  default     = "ubuntu-os-cloud/ubuntu-minimal-2004-lts"
+  # default     = "cos-cloud/cos-stable"  # May be useful to have a more locked-down environment, just to run Docker images.
+}

--- a/deploy/gcp/gce/variables.tf
+++ b/deploy/gcp/gce/variables.tf
@@ -42,7 +42,7 @@ variable "gcp_machine_type" {
   # - https://cloud.google.com/compute/docs/machine-types
   # - $ gcloud compute machine-types list
   description = "Google Cloud Platform's selected machine type"
-  default     = "f1-micro"
+  default     = "g1-small"
 }
 
 variable "gcp_os_image" {


### PR DESCRIPTION
Contains:

- Initialisation script (`gcloud` bootstrapping, etc.)
- Terraform template for:

  - a `g1-small` VM
    (for now, to limit credits consumption; it may need to be bigger to actually host ICUBAM)
  - a public IP

- Documentation
- Lint Terraform templates via `terraform fmt -check`

Next steps:

- Add installation of ICUBAM itself