### PR TITLE
Re-add plot tests for analytics module

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,7 +5,7 @@ coverage:
     project:
       default:
         # Commits pushed to master should not make the overall
-        # project coverage decrease by more than 4%:
+        # project coverage decrease by more than this value:
         target: auto
         threshold: 4%
     patch:
@@ -18,4 +18,4 @@ coverage:
         # extension:
         # https://github.com/codecov/browser-extension
         target: auto
-        threshold: 50%
+        threshold: 15%

--- a/icubam/analytics/plots/__init__.py
+++ b/icubam/analytics/plots/__init__.py
@@ -72,9 +72,13 @@ def plot_int(
   fill_below=False,
   kind="quadratic"
 ):
-  f = scipy.interpolate.interp1d(x, y, kind=kind)
-  x_i = np.linspace(0, len(x) - 1, len(x) * 5)
-  y_i = f(x_i)
+  if len(x) > 1:
+    f = scipy.interpolate.interp1d(x, y, kind=kind)
+    x_i = np.linspace(0, len(x) - 1, len(x) * 5)
+    y_i = f(x_i)
+  else:
+    x_i = x
+    y_i = y
   if marker is not None:
     ax.scatter(x, y, marker=marker, color=color)
   if fill_below:

--- a/icubam/analytics/plots/__init__.py
+++ b/icubam/analytics/plots/__init__.py
@@ -72,13 +72,12 @@ def plot_int(
   fill_below=False,
   kind="quadratic"
 ):
-  if len(x) > 1:
-    f = scipy.interpolate.interp1d(x, y, kind=kind)
-    x_i = np.linspace(0, len(x) - 1, len(x) * 5)
-    y_i = f(x_i)
-  else:
-    x_i = x
-    y_i = y
+  if len(x) <= 1:
+    # Linear interpolation requires at least 2 entries
+    kind = "zero"
+  f = scipy.interpolate.interp1d(x, y, kind=kind)
+  x_i = np.linspace(0, len(x) - 1, len(x) * 5)
+  y_i = f(x_i)
   if marker is not None:
     ax.scatter(x, y, marker=marker, color=color)
   if fill_below:

--- a/icubam/analytics/preprocessing.py
+++ b/icubam/analytics/preprocessing.py
@@ -302,8 +302,14 @@ def spread_cum_jumps(d, icu_to_first_input_date):
       for col in cols:
         if col in already_fixed_col:
           continue
-        beg_val = dg.loc[dg.date == beg, col].values[0]
-        end_val = dg.loc[dg.date == end, col].values[0]
+        beg_val = dg.loc[dg.date == beg, col]
+        if not len(beg_val):
+          continue
+        beg_val = beg_val.values[0]
+        end_val = dg.loc[dg.date == end, col]
+        if not len(end_val):
+          continue
+        end_val = end_val.values[0]
         diff = end_val - beg_val
         if diff >= SPREAD_CUM_JUMPS_MAX_JUMP[col]:
           spread_beg = dg.date.min()

--- a/icubam/analytics/preprocessing.py
+++ b/icubam/analytics/preprocessing.py
@@ -278,6 +278,7 @@ def enforce_daily_values_for_all_icus(d):
 
 def spread_cum_jumps(d, icu_to_first_input_date):
   assert np.all(d.date.values == d.datetime.values)
+  # TODO: do not hardcode this value
   date_begin_transfered_refused = pd.to_datetime("2020-03-25").date()
   dfs = []
   for icu_name, dg in d.groupby("icu_name"):

--- a/icubam/analytics/tests/test_plot.py
+++ b/icubam/analytics/tests/test_plot.py
@@ -1,0 +1,63 @@
+from pathlib import Path
+
+import pytest
+import sqlalchemy
+
+import icubam.db.store as db_store
+from icubam.db.fake import populate_store_fake
+from icubam.analytics.plots import PLOTS, generate_plots
+from icubam.analytics.preprocessing import preprocess_bedcounts
+from icubam.analytics import dataset
+
+
+@pytest.fixture
+def fake_db():
+  store_factory = db_store.StoreFactory(
+    sqlalchemy.create_engine("sqlite:///:memory:", echo=False)
+  )
+  db = store_factory.create()
+  populate_store_fake(db)
+  return db
+
+
+def test_generate_plots_wrong_name():
+  msg = "Unknown plot.* invalid2"
+  with pytest.raises(ValueError, match=msg):
+    generate_plots(plots=["invalid2"], data={})
+
+
+def check_generate_plots(name, db, output_dir):
+  data = {}
+  bc = dataset.load_bed_counts(db)
+  data['bedcounts'] = preprocess_bedcounts(bc)
+  assert data['bedcounts'].shape[0] > 0
+  generate_plots(plots=[name], output_dir=output_dir, data=data)
+  output_dir = Path(output_dir)
+  if name == "barplot_flow_per":
+    assert (output_dir / "National-CUM_FLOW_7D.png").exists()
+  elif name == "lineplot_beds_per":
+    assert (output_dir / 'National-LINE_BEDS_PER_14D_COVID.png').exists()
+  else:
+    raise ValueError
+
+
+@pytest.mark.parametrize("name", PLOTS)
+def test_fake_generate_plots(name, tmpdir, fake_db):
+  output_dir = str(tmpdir.mkdir("out"))
+  check_generate_plots(name, fake_db, output_dir)
+  output_dir = Path(output_dir)
+  if name == "barplot_flow_per":
+    assert (output_dir / "region_id=1-Paris-CUM_FLOW.png").exists()
+  elif name == "lineplot_beds_per":
+    assert (output_dir / 'region_id=1-Paris-LINE_BEDS_PER_COVID.png').exists()
+  else:
+    raise ValueError
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("name", PLOTS)
+def test_integration_generate_plots(name, integration_config, tmpdir):
+  store = db_store.create_store_factory_for_sqlite_db(integration_config
+                                                      ).create()
+  output_dir = str(tmpdir.mkdir("out"))
+  check_generate_plots(name, store, output_dir)

--- a/icubam/analytics/tests/test_preprocessing.py
+++ b/icubam/analytics/tests/test_preprocessing.py
@@ -10,16 +10,19 @@ from icubam.db.fake import populate_store_fake
 @pytest.fixture
 def fake_db():
   store_factory = store.StoreFactory(
-    sqla.create_engine("sqlite:///:memory:", echo=True)
+    sqla.create_engine("sqlite:///:memory:", echo=False)
   )
   db = store_factory.create()
   populate_store_fake(db)
   return db
 
 
-def test_bedcounts_data_preprocessing(fake_db):
+@pytest.mark.parametrize('spread_cum_jumps', [False, True])
+def test_bedcounts_data_preprocessing(fake_db, spread_cum_jumps):
   data = dataset.load_bed_counts(fake_db)
-  preprocessed = preprocessing.preprocess_bedcounts(data)
+  preprocessed = preprocessing.preprocess_bedcounts(
+    data, spread_cum_jump_correction=spread_cum_jumps
+  )
   assert len(preprocessed) > 0
   for icu_name, dg in preprocessed.groupby('icu_name'):
     dg = dg.sort_values(by='create_date')

--- a/icubam/analytics/tests/test_preprocessing.py
+++ b/icubam/analytics/tests/test_preprocessing.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-import sqlalchemy as sqla
+import sqlalchemy
 
 from icubam.analytics import dataset, preprocessing
 from icubam.db import store
@@ -10,7 +10,7 @@ from icubam.db.fake import populate_store_fake
 @pytest.fixture
 def fake_db():
   store_factory = store.StoreFactory(
-    sqla.create_engine("sqlite:///:memory:", echo=False)
+    sqlalchemy.create_engine("sqlite:///:memory:", echo=False)
   )
   db = store_factory.create()
   populate_store_fake(db)


### PR DESCRIPTION
Re-adds some of the predicu tests for plots that didn't get included in https://github.com/icubam/icubam/pull/389
(otherwise plots are currently untested).

Also test the `spread_cum_jump` option in `preprocess_bedcounts`.