### PR TITLE
Faster /version endpoint

### DIFF
--- a/icubam/www/handlers/version.py
+++ b/icubam/www/handlers/version.py
@@ -23,7 +23,7 @@ class VersionHandler(base.BaseHandler):
     except Exception:
       git_hash = 'NA'
     data['git-hash'] = git_hash
-    bed_counts = self.db.get_bed_counts()
+    bed_counts = self.db.get_bed_counts(latest=True)
     last_modified = max([el.last_modified for el in bed_counts], default='NA')
     data['bed_counts.last_modified'] = str(last_modified)
     return data


### PR DESCRIPTION
The /version endpoint is currently extremely slow (2s locally, 10s on prod server) because a query of all bedcounts is done as part of health checks (and that grows slower with more data).

Querying only latest bedcounts for each ICU is much faster (30ms locally). Assuming we still want to do some queries in this endpoint as opposed to just returning the version.