### PR TITLE
Add Web API documentation and update release notes 

### DIFF
--- a/.github/doc-requirements.txt
+++ b/.github/doc-requirements.txt
@@ -1,3 +1,4 @@
 sphinx
 sphinx_rtd_theme
 recommonmark
+sphinxcontrib-httpdomain

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ with the ministry of health (only ARS Est for now)'s back-end system for
 - and retrieving data to synchronise with other data sources.
 
 This software is open-source and made available on
-[GitHUb](https://github.com/icubam/icubam).
+[GitHub](https://github.com/icubam/icubam). See the documentation for more details: [docs.icubam.net](https://docs.icubam.net).
 
 It will soon be released as a one-click deployable docker container.
 

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -1,0 +1,97 @@
+Web API
+=======
+
+This page summarizes the API endpoints that are exposed by different ICUBAM services.
+Note that you may need a prefix to the listed URLs depending on the deployment options
+(and in particular the ``base_url`` config parameter of each service).
+
+Main service
+------------
+
+.. http:get:: /
+
+   Shows the map with ICUS. Requires the user to be authenticated.
+
+.. http:get:: /map
+
+   Shows the map with ICUS. Same as / endpoint but accessed with an API KEY.
+
+   :query API_KEY: a valid API KEY of type ``MAP`` or ``ALL``.
+
+.. http:get:: /version
+
+   Returns the current version.
+
+   **Example response**
+
+   .. sourcecode:: json
+
+       {'data': {
+          'version': 'v0.5.1',
+          'git-hash': '7416eefc',
+          'bed_counts.last_modified': '2020-05-29 12:00'
+          }
+        }
+
+.. http:get:: /consent
+
+   A HTTP page with consent handler.
+
+.. http:get:: /disclamer
+ 
+   Shows a disclaimer page specified in the configuration.
+
+.. http:get:: /error
+
+   Renders the error template.
+
+.. http:get:: /update
+
+   Get a form to update bed counts information for an ICU
+
+   :query id: authentication token which encodes user id and ICU id.
+
+
+.. http:get:: /dashboard
+
+   :query API_KEY: a valid API KEY of type ``STATS`` or ``ALL``.
+
+Analytics service
+-----------------
+
+.. http:get:: /db/(str:resource)
+
+   Export a given resource. Supported resources are ``bedcounts``, ``all_bedcounts``,
+   ``icus``, ``regions``.
+
+   :query format: The format of the response. Possible values are ``csv`` or ``html``.
+   :query max_ts: Maximum timestamp for the response.
+
+   :query API_KEY: a valid API KEY of type ``STATS`` or ``ALL``.
+
+.. http:post:: /db/(str:resource)
+
+   Import a given resource. The only supported resource is `bedcounts` at present.
+
+   :query API_KEY: a valid API KEY of type ``STATS`` or ``ALL``.
+   :query format: File format. Must be set to ``ror_idf``.
+
+
+Backoffice service
+------------------
+
+The backoffice server does not expose a public API and is intended to be used a
+web application directly.
+
+Messaging service
+-----------------
+
+.. http:post:: /onoff
+
+   Enable or disable messaging for a set of users. The information is encoded
+   in the request body as a JSON containing ``user_id``, ``icu_ids`` and ``od``
+   fields.
+
+.. http:get:: /schedule
+
+   This handler returns all the scheduled messages information.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -29,6 +29,7 @@ author = 'icubam'
 extensions = [
   "sphinx_rtd_theme",
   "recommonmark",
+  "sphinxcontrib.httpdomain",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -27,6 +27,7 @@ fill in 15 seconds.
 
    authentication.md
    backoffice.md
+   api.md
    cli.md
 
 

--- a/doc/whats_new.md
+++ b/doc/whats_new.md
@@ -1,8 +1,23 @@
 # Release notes
 
-## v0.2.5
+## v0.5.2
 
- - A required `extra_plots_dir` parameter was added to `config.toml`.
-   See [backoffice.md](./backoffice.md) for more details.
-   [#208](https://github.com/icubam/icubam/pull/208)
+ - Added a standalone analytics service which
+   - periodically re-generates plots for the dashboard
+   - exposes the import/export endpoints
+   without blocking the main server (#407)
+ - Added sphinx documentation available at
+   [docs.icubam.net](https://docs.icubam.net) (#417)
+ -  Add `--create-admin` option to `scripts/update_password.py` (#409) 
+
+## v0.5.1
+
+ - Use docker hub (#406)
+ - Add Docker user envvar (#400)
+ - Add Terraform template to create VM under GCP (#398)
+ - Update nginx configurations to handle proxy with no ssl endpoint (#414)
+ - Add disclaimer link on maps (#397) 
+ - Faster ``/version`` endpoint (#411) 
+ - Fix bug in ``plot_each_region`` (#413) 
+
 


### PR DESCRIPTION
A constraint with the API docs is that they are not updated automatically (e.g. with OpenAPI etc) and so have to be manually updated each time there is a change in handlers. Since we don't plan much changes in the future it should be OK I think.

**Edit:** rendered version in https://test-doc-icubam.readthedocs.io/en/web-api/api.html